### PR TITLE
Fix quest list

### DIFF
--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -8254,7 +8254,7 @@ Public Sub HandleQuestListSend()
         
         'Agregamos los items
         For i = 1 To tmpByte
-            FrmQuests.lstQuests.AddItem ReadField(i, tmpStr, 45)
+            FrmQuests.lstQuests.AddItem ReadField(i, tmpStr, 59)
         Next i
 
     End If


### PR DESCRIPTION
hay quest con nombre con guiones que rompen la lista de quest si lo usamos para splitear string, lo cambie a un caracter menos probable para nombre de quest (";")