### PR TITLE
Fix sonido al navegar y cabalgar

### DIFF
--- a/CODIGO/TileEngine.bas
+++ b/CODIGO/TileEngine.bas
@@ -741,41 +741,41 @@ End Function
 Sub DoPasosFx(ByVal charindex As Integer)
     
     On Error GoTo DoPasosFx_Err
-    
+   
+    With charlist(CharIndex)
 
-    Static TerrenoDePaso As TipoPaso
+        If Not .Muerto And EstaPCarea(CharIndex) And .priv <= charlist(UserCharIndex).priv And charlist(UserCharIndex).Muerto = False Then
+            .Pie = Not .Pie
+            
+            Dim StepIndex As Byte: StepIndex = IIf(.Pie, 1, 2)
+            Dim TerrenoDePaso As Byte
+            
+            If .Navegando Then
+                TerrenoDePaso = CONST_AGUA
+            ElseIf MapData(.Pos.x, .Pos.y).Graphic(1).GrhIndex > 0 Then
+                Dim FileNum As Long: FileNum = GrhData(MapData(.Pos.x, .Pos.y).Graphic(1).GrhIndex).FileNum
+                TerrenoDePaso = GetTerrenoDePaso(FileNum, MapData(.Pos.x, .Pos.y).Graphic(2).GrhIndex)
+                If .Speeding > 1.2 And TerrenoDePaso = CONST_PISO Then
+                    TerrenoDePaso = CONST_CABALLO
+                End If
+            Else
+                TerrenoDePaso = CONST_PISO
+            End If
 
-    Static FileNum       As Integer
-
-    If Not charlist(charindex).Navegando Then
-
-        With charlist(charindex)
             Dim steps_vol As Long
             Dim steps_pan As Long
             steps_vol = ao20audio.ComputeCharFxVolume(.Pos)
             steps_pan = ao20audio.ComputeCharFxPan(.Pos)
-            If Not .Muerto And EstaPCarea(charindex) And .priv <= charlist(UserCharIndex).priv And charlist(UserCharIndex).Muerto = False Then
-                If .Speeding > 1.3 Then
-                    Call ao20audio.PlayWav(Pasos(CONST_CABALLO).wav(1), False, steps_vol, steps_pan)
-                    Exit Sub
-                End If
-           
-                .Pie = Not .Pie
 
-                If .Pie Then
-                    If MapData(.Pos.x, .Pos.y).Graphic(1).GrhIndex > 0 Then
-                        FileNum = GrhData(MapData(.Pos.x, .Pos.y).Graphic(1).GrhIndex).FileNum
-                        TerrenoDePaso = GetTerrenoDePaso(FileNum, MapData(.Pos.x, .Pos.y).Graphic(2).GrhIndex)
-                        If TerrenoDePaso <> CONST_AGUA Then
-                            Call ao20audio.PlayWav(Pasos(TerrenoDePaso).wav(1), False, steps_vol, steps_pan)
-                        End If
-                    End If
-                Else
-                    Call ao20audio.PlayWav(Pasos(TerrenoDePaso).wav(2), False, steps_vol, steps_pan)
-                End If
-            End If
-        End With
-    End If
+            Dim SndIndex As Integer: SndIndex = Pasos(TerrenoDePaso).wav(StepIndex)
+            Dim SndLabel As String: SndLabel = "pasos" & CharIndex & "_" & StepIndex
+
+            Call ao20audio.StopWav(SndIndex, SndLabel)
+            Call ao20audio.PlayWav(SndIndex, False, steps_vol, steps_pan, SndLabel)
+
+        End If
+    
+    End With
     
     Exit Sub
 

--- a/CODIGO/clsAudioEngine.cls
+++ b/CODIGO/clsAudioEngine.cls
@@ -241,7 +241,7 @@ Private Function FindTrackByName(ByVal Name As String, Optional ByVal label As S
             With mAudioTracks(i)
                 If Not .Buffer Is Nothing Then
                     Dim sf As CONST_DSBSTATUSFLAGS: sf = .Buffer.GetStatus
-                    If (Name = .Name) And (label = .label) And (DSBSTATUS_PLAYING And sf) = DSBSTATUS_PLAYING And (DSBSTATUS_LOOPING And sf) = DSBSTATUS_LOOPING Then
+                    If (Name = .Name) And (label = .label) And (DSBSTATUS_PLAYING And sf) = DSBSTATUS_PLAYING Then
                         FindTrackByName = i
                         Exit Function
                     End If


### PR DESCRIPTION
Fixes ao-org/argentum-online-server#456

Agrego un label a los pasos para poder detener el sonido de los pasos anteriores (por personaje).
También arreglo el sonido del caballo cuando está sobre piso.