### PR TITLE
La lista de clanes debe mostrar alineación Todos por defecto

### DIFF
--- a/CODIGO/frmGuildAdm.frm
+++ b/CODIGO/frmGuildAdm.frm
@@ -223,7 +223,7 @@ Private Sub Form_Load()
     Me.Picture = LoadInterface("ventanaclanes.bmp")
     
     Call LoadButtons
-    Combo1.ListIndex = 2
+    Combo1.ListIndex = 5
 
     
     Exit Sub


### PR DESCRIPTION
Solo cambio en la UI vieja. Si bien se mostraban todos los clanes, en el select se leía "Legión Oscura" por defecto