### PR TITLE
Chequeos de sonido en PC area + revierto la atenuación de volúmen

### DIFF
--- a/CODIGO/TileEngine.bas
+++ b/CODIGO/TileEngine.bas
@@ -734,7 +734,7 @@ Sub DoPasosFx(ByVal charindex As Integer)
    
     With charlist(CharIndex)
 
-        If Not .Muerto And .priv <= charlist(UserCharIndex).priv And charlist(UserCharIndex).Muerto = False Then
+        If EstaPCarea(CharIndex) And Not .Muerto And .priv <= charlist(UserCharIndex).priv And charlist(UserCharIndex).Muerto = False Then
             .Pie = Not .Pie
             
             Dim StepIndex As Byte: StepIndex = IIf(.Pie, 1, 2)

--- a/CODIGO/TileEngine_Chars.bas
+++ b/CODIGO/TileEngine_Chars.bas
@@ -476,7 +476,7 @@ Char_Move_by_Pos_Err:
     
 End Sub
 
-Private Function EstaPCarea(ByVal charindex As Integer) As Boolean
+Public Function EstaPCarea(ByVal CharIndex As Integer) As Boolean
     
     On Error GoTo EstaPCarea_Err
     

--- a/CODIGO/ao20audio.bas
+++ b/CODIGO/ao20audio.bas
@@ -172,7 +172,7 @@ End Function
 Public Function ComputeCharFxVolume(ByRef Pos As Position) As Long
 On Error GoTo ComputeCharFxVolumenErr:
     Dim total_distance As Integer
-    total_distance = distance(Pos.x, Pos.y, UserPos.x, UserPos.y)
+    total_distance = General_Distance_Get(Pos.x, Pos.y, UserPos.x, UserPos.y)
     ComputeCharFxVolume = ComputeCharFxVolumeByDistance(total_distance)
     Exit Function
 ComputeCharFxVolumenErr:
@@ -233,10 +233,8 @@ End Function
 Public Function ComputeCharFxVolumeByDistance(ByVal distance As Byte) As Long
 On Error GoTo ComputeCharFxVolumeByDistance_err:
     distance = Abs(distance)
-    If distance <= 8 Then
-        ComputeCharFxVolumeByDistance = VolFX - distance * 80
-    ElseIf distance < 20 Then
-        ComputeCharFxVolumeByDistance = VolFX - 640 - (distance - 8) * 200
+    If distance < 20 Then
+        ComputeCharFxVolumeByDistance = VolFX - distance * 120
         If ComputeCharFxVolumeByDistance < -4000 Then ComputeCharFxVolumeByDistance = -4000
     Else
         ComputeCharFxVolumeByDistance = -4000

--- a/CODIGO/engine.bas
+++ b/CODIGO/engine.bas
@@ -4404,7 +4404,9 @@ Public Sub Effect_Render_Slot(ByVal effect_Index As Integer)
                 If (.End_Effect <> 0) And .DestinoChar <> 0 Then
                     If .DestinoChar <> 0 Then
                         Call General_Char_Particle_Create(.End_Effect, .DestinoChar, .End_Loops)
-                        Call ao20audio.playwav(.wav, False, ao20audio.ComputeCharFxVolume(charlist(.DestinoChar).Pos), ao20audio.ComputeCharFxPan(charlist(.DestinoChar).Pos))
+                        If EstaPCarea(.DestinoChar) Then
+                            Call ao20audio.PlayWav(.wav, False, ao20audio.ComputeCharFxVolume(charlist(.DestinoChar).Pos), ao20audio.ComputeCharFxPan(charlist(.DestinoChar).Pos))
+                        End If
                         .Slot_Used = False
                         Exit Sub
 
@@ -4419,14 +4421,18 @@ Public Sub Effect_Render_Slot(ByVal effect_Index As Integer)
                     Dim dest_pos As Position
                     dest_pos.x = .DestX
                     dest_pos.y = .DesyY
-                    Call ao20audio.playwav(.wav, False, ao20audio.ComputeCharFxVolume(dest_pos), ao20audio.ComputeCharFxPan(dest_pos))
+                    If EstaEnArea(.DestX, .DesyY) Then
+                        Call ao20audio.PlayWav(.wav, False, ao20audio.ComputeCharFxVolume(dest_pos), ao20audio.ComputeCharFxPan(dest_pos))
+                    End If
                     .Slot_Used = False
                     Exit Sub
 
                 End If
             
                 If (.FxEnd_Effect > 0) And .DestinoChar <> 0 Then
-                    Call ao20audio.playwav(.wav, False, ao20audio.ComputeCharFxVolume(charlist(.DestinoChar).Pos), ao20audio.ComputeCharFxPan(charlist(.DestinoChar).Pos))
+                    If EstaPCarea(.DestinoChar) Then
+                        Call ao20audio.PlayWav(.wav, False, ao20audio.ComputeCharFxVolume(charlist(.DestinoChar).Pos), ao20audio.ComputeCharFxPan(charlist(.DestinoChar).Pos))
+                    End If
                     Call SetCharacterFx(.DestinoChar, .FxEnd_Effect, .End_Loops)
                     .Slot_Used = False
                     Exit Sub
@@ -4437,7 +4443,9 @@ Public Sub Effect_Render_Slot(ByVal effect_Index As Integer)
                     Dim p As Position
                     p.x = .DestX
                     p.y = .DesyY
-                    Call ao20audio.playwav(.wav, False, ao20audio.ComputeCharFxVolume(p), ao20audio.ComputeCharFxPan(p))
+                    If EstaEnArea(.DestX, .DesyY) Then
+                        Call ao20audio.PlayWav(.wav, False, ao20audio.ComputeCharFxVolume(P), ao20audio.ComputeCharFxPan(P))
+                    End If
                     Call SetMapFx(.DestX, .DesyY, .FxEnd_Effect, 0)
                     .Slot_Used = False
                     Exit Sub


### PR DESCRIPTION
Ahora ningún sonido de usuario debería escucharse por fuera de la pantalla.

Vuelvo la atenuación de volúmen al cálculo que tenía antes.