### PR TITLE
Fix meditar invi

### DIFF
--- a/CODIGO/General.bas
+++ b/CODIGO/General.bas
@@ -781,7 +781,7 @@ Sub MoveTo(ByVal Heading As E_Heading, ByVal Dumb As Boolean)
             
             Dim i As Integer
             For i = 1 To LastChar
-                If charlist(i).Invisible And Not EsGM Then
+                If charlist(i).Invisible And Not EsGM And Not charlist(i).Meditating Then
                     If MapData(charlist(i).Pos.x, charlist(i).Pos.y).charindex = i And (charlist(UserCharIndex).clan_nivel < 6 Or charlist(i).clan_index = 0 Or charlist(i).clan_index <> charlist(UserCharIndex).clan_index) And Not charlist(i).Navegando Then
                         If General_Distance_Get(charlist(i).Pos.x, charlist(i).Pos.y, UserPos.x, UserPos.y) > DISTANCIA_ENVIO_DATOS And charlist(i).dialog_life = 0 And charlist(i).FxCount = 0 And charlist(i).particle_count = 0 Then
                             MapData(charlist(i).Pos.x, charlist(i).Pos.y).charindex = 0

--- a/CODIGO/TileEngine.bas
+++ b/CODIGO/TileEngine.bas
@@ -278,6 +278,8 @@ Public Type Char
     appear As Byte
     simbolo As Byte
     Idle As Boolean
+    
+    Meditating As Boolean
 
     Head_Aura As String
     Body_Aura As String

--- a/CODIGO/TileEngine_Chars.bas
+++ b/CODIGO/TileEngine_Chars.bas
@@ -69,6 +69,7 @@ Public Sub ResetCharInfo(ByVal charindex As Integer)
         .MaxBarTime = 0
         .UserMaxHp = 0
         .UserMinHp = 0
+        .Meditating = False
         .ActiveAnimation.PlaybackState = Stopped
         .scrollDirectionX = 0
         .scrollDirectionY = 0


### PR DESCRIPTION
- Agrego flag para saber si un char está meditando, en base a si tiene un FX al crear o cambiar el char
- Usando el flag evito borrar el char hasta que deje de meditar (para ver la meditación aunque esté invisible)
- El checkeo de rango de visión de la meditación lo dejo sólo para reproducir el sonido y no para detenerlo. Y tampoco afecta la animación. Así no queda el sonido loopeando ni la meditación bugueada.