### PR TITLE
Revert "NoMapInfo prop for npcs"

### DIFF
--- a/CODIGO/ModUtils.bas
+++ b/CODIGO/ModUtils.bas
@@ -266,7 +266,6 @@ Public Type NpcDatas
     QuizaDropea() As Integer
     ExpClan As Long
     PuedeInvocar As Byte
-    NoMapInfo As Boolean
     
 End Type
 

--- a/CODIGO/Recursos.bas
+++ b/CODIGO/Recursos.bas
@@ -1755,10 +1755,6 @@ Public Sub CargarIndicesOBJ()
     
     For Npc = 1 To NumNpcs
         DoEvents
-
-        If(NpcData(Npc).NoMapInfo = CBool(Val(Leer.GetValue("npc" & Npc, "NoMapInfo")))) Then
-            Next Npc
-        End If
         
         Select Case language
             Case e_language.English
@@ -1786,7 +1782,7 @@ Public Sub CargarIndicesOBJ()
         NpcData(Npc).ExpClan = Val(Leer.GetValue("npc" & Npc, "GiveEXPClan"))
         
         NpcData(Npc).PuedeInvocar = Val(Leer.GetValue("npc" & Npc, "PuedeInvocar"))
-        NpcData(Npc).NoMapInfo = CBool(Val(Leer.GetValue("npc" & Npc, "NoMapInfo")))
+       
         aux = Val(Leer.GetValue("npc" & Npc, "NumQuiza"))
 
         If aux = 0 Then


### PR DESCRIPTION
Reverts ao-org/argentum-online-client#354

Revierto PR por que no compila.

```
Compile Error in File 'C:\re20-cliente-master\CODIGO\Recursos.bas', Line 1758 : Next without For
Build of 'Argentum.exe' failed.
```

@Centorios 