### PR TITLE
Fixed mostrarCartel function for tutorial and skills button error

### DIFF
--- a/CODIGO/ModTutorial.bas
+++ b/CODIGO/ModTutorial.bas
@@ -126,8 +126,8 @@ Public Sub resetearCartel()
     cartel_visible = False
 End Sub
 'Duration = 0 calcula solo con largo de texto, Duration = -1 infinito
-Public Sub mostrarCartel(ByVal title As String, ByVal message As String, Optional ByVal headGrh As Long = 0, Optional ByVal bodyGrh As Long = 0, Optional ByVal Duration As Long = 0, Optional ByVal titleColor As Long = -1, Optional ByVal messageColor As Long = -1, Optional ByVal backgroundColor As Long = -1, Optional ByVal esNpc As Boolean = False, Optional ByVal CartelTitlePosX = 0, Optional ByVal CartelTitlePosY As Long = 0, Optional ByVal CartelMessagePosX As Long = 0, Optional ByVal CartelMessagePosY As Long = 0, Optional ByVal cartelGrhPosX As Long = 0, Optional ByVal cartelGrhPosY As Long = 0, Optional ByVal grhWidth As Long = 0, Optional ByVal grhHeight As Long = 0, Optional ByVal headOffsetY As Integer = 0)
-    
+
+Public Sub mostrarCartel(ByVal title As String, ByVal Message As String, Optional ByVal headGrh As Long = 0, Optional ByVal duration As Long = 0, Optional ByVal titleColor As Long = -1, Optional ByVal messageColor As Long = -1, Optional ByVal backgroundColor As Long = -1, Optional ByVal EsNpc As Boolean = False, Optional ByVal CartelTitlePosX = 0, Optional ByVal CartelTitlePosY As Long = 0, Optional ByVal CartelMessagePosX As Long = 0, Optional ByVal CartelMessagePosY As Long = 0, Optional ByVal cartelGrhPosX As Long = 0, Optional ByVal cartelGrhPosY As Long = 0, Optional ByVal grhWidth As Long = 0, Optional ByVal grhHeight As Long = 0, Optional ByVal bodyGrh As Long = 0, Optional ByVal HeadOffsetY As Integer = 0)
     Dim titleColor_byte() As Byte
     Dim messageColor_byte() As Byte
     Dim backgroundColor_byte() As Byte
@@ -277,6 +277,7 @@ Public Sub RenderScreen_Cartel()
         End If
         If cartel_head_grh.GrhIndex > 0 Then
             Call Grh_Render_Advance(cartel_head_grh, cartel_grh_pos_x, cartel_grh_pos_y + offsetHead, grh_height, grh_width, cartel_icono_color())
+            Call Grh_Render_Advance(cartel_head_grh, cartel_grh_pos_x, cartel_grh_pos_y + cartel_head_offset_y, grh_height, grh_width, cartel_icono_color())
         End If
     End If
     
@@ -502,7 +503,7 @@ Public Sub checkTutorial()
         '    If tutorial(e_tutorialIndex.TUTORIAL_NUEVO_USER).Activo = 1 Then
         '        tutorial_index = e_tutorialIndex.TUTORIAL_NUEVO_USER
         '        mascota.visible = True
-        '        Call mostrarCartel(tutorial(tutorial_index).titulo, tutorial(tutorial_index).textos(1), 275,0, -1, &H164B8A, , , False, 100, 479, 100, 535, 640, 490, 64, 64)
+        '        Call mostrarCartel(tutorial(tutorial_index).titulo, tutorial(tutorial_index).textos(1), 275, -1, &H164B8A, , , False, 100, 479, 100, 535, 640, 490, 64, 64)
         '    End If
         'End If
     Else

--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -1893,7 +1893,7 @@ On Error GoTo HandleUpdateHP_Err
         If MostrarTutorial And tutorial_index <= 0 Then
             If tutorial(e_tutorialIndex.TUTORIAL_Muerto).Activo = 1 Then
                 tutorial_index = e_tutorialIndex.TUTORIAL_Muerto
-                Call mostrarCartel(tutorial(tutorial_index).titulo, tutorial(tutorial_index).textos(1), tutorial(tutorial_index).Grh, 0, -1, &H164B8A, , , False, 100, 479, 100, 535, 640, 530, 50, 100)
+                Call mostrarCartel(tutorial(tutorial_index).titulo, tutorial(tutorial_index).textos(1), tutorial(tutorial_index).Grh, -1, &H164B8A, , , False, 100, 479, 100, 535, 640, 530, 50, 100)
             End If
         End If
         DrogaCounter = 0
@@ -2317,19 +2317,22 @@ On Error GoTo ErrHandler
         Case "NPCDESC"
             chat = NpcData(text).desc
             copiar = False
+            
             If npcs_en_render And tutorial_index <= 0 Then
                 Dim headGrh As Long
                 Dim bodyGrh As Long
                 headGrh = HeadData(NpcData(Text).Head).Head(3).GrhIndex
                 bodyGrh = GrhData(BodyData(NpcData(Text).Body).Walk(3).GrhIndex).Frames(1)
+                
                 If headGrh = 0 Then
-                    Call mostrarCartel(Split(NpcData(Text).Name, " <")(0), NpcData(Text).desc, 0, bodyGrh, 200 + 30 * Len(chat), &H164B8A, , , True, 100, 479, 100, 535, 20, 500, 50, 80, 0)
+                    Call mostrarCartel(Split(NpcData(Text).Name, " <")(0), NpcData(Text).desc, bodyGrh, 200 + 30 * Len(chat), &H164B8A, , , True, 100, 479, 100, 535, 20, 500, 50, 80, bodyGrh, 1)
                 Else
                     Dim headOffsetY As Integer
                     headOffsetY = CInt(BodyData(NpcData(Text).Body).HeadOffset.y)
-                    Call mostrarCartel(Split(NpcData(Text).Name, " <")(0), NpcData(Text).desc, headGrh, bodyGrh, 200 + 30 * Len(chat), &H164B8A, , , True, 100, 479, 100, 535, 20, 500, 38, 80, headOffsetY * 1.5)
+                    Call mostrarCartel(Split(NpcData(Text).Name, " <")(0), NpcData(Text).desc, headGrh, 200 + 30 * Len(chat), &H164B8A, , , True, 100, 479, 100, 535, 20, 500, 50, 100, bodyGrh, HeadOffsetY)
                 End If
             End If
+            
         Case "PMAG"
             chat = HechizoData(ReadField(2, chat, Asc("*"))).PalabrasMagicas
             If charlist(UserCharIndex).Muerto = True Then chat = ""

--- a/CODIGO/TileEngine_Map.bas
+++ b/CODIGO/TileEngine_Map.bas
@@ -107,8 +107,7 @@ Sub SwitchMap(ByVal Map As Integer, Optional ByVal NewResourceMap As Integer = 0
             If tutorial(e_tutorialIndex.TUTORIAL_ZONA_INSEGURA).Activo = 1 Then
                 tutorial_index = e_tutorialIndex.TUTORIAL_ZONA_INSEGURA
                 'TUTORIAL MAPA INSEGURO
-                Call mostrarCartel(tutorial(tutorial_index).titulo, tutorial(tutorial_index).textos(1), tutorial(tutorial_index).Grh, 0, _
-                -1, &H164B8A, , , False, 100, 479, 100, 535, 640, 530, 64, 64)
+                Call mostrarCartel(tutorial(tutorial_index).titulo, tutorial(tutorial_index).textos(1), tutorial(tutorial_index).Grh, -1, &H164B8A, , , False, 100, 479, 100, 535, 640, 530, 64, 64)
             End If
         End If
         frmMain.Coord.ForeColor = RGB(170, 0, 0)


### PR DESCRIPTION
Recent changes broke the skills button and it throw this error:
![image](https://github.com/ao-org/argentum-online-client/assets/5874806/ca49500a-311f-4672-b385-a1cc96eaccb7)

```
Error: 9
Descripcion: El subíndice está fuera del intervalo
Componente: frmMain.EstadisticasBoton_MouseUp
Linea: 0
Fecha y Hora: 05-27-2024-02:11:41
```


Now it works fine and the NPCs are rendered fine in the tutorial
![image](https://github.com/ao-org/argentum-online-client/assets/5874806/e9d6cad6-a639-40f8-a442-cf5e9d661e96)
