### PR TITLE
Iluminación de los dungeons

### DIFF
--- a/CODIGO/ModMetereologia.bas
+++ b/CODIGO/ModMetereologia.bas
@@ -120,7 +120,7 @@ Public Sub IniciarMeteorologia()
     Call SetRGBA(BlindColor, 4, 4, 4)
     
     ' Dungeon
-    Call SetRGBA(DungeonColor, 130, 130, 130)
+    Call SetRGBA(DungeonColor, 190, 190, 190)
     
     TimeIndex = -1
 


### PR DESCRIPTION
Problema: Los dungeon oscuros tienen muy poca iluminación por defecto, y los jugadores clickean en el mapa por necesidad de ver mejor, ya que hacer esto cambia la ilumiación del mapa. La única excepción son los polos, en donde si cambias la iluminación te quedas ciego de lo blanco que es.
Solución: Más allá de que clickear el mapa no debería cambiar la iluminación, subí la ilumnación de los dungeon para que la gente no tenga la necesidad de clickear el mapa:
- Se ve más iluminado dentro de los dungeon que son oscuros, como DV, permitiendo conservar el efecto de las antorchas pero logrando mejor visibilidad
- No hace falta clickear fuera para dungeon como polo ya que por defecto se ve bien.