### PR TITLE
Corrijo el hogar en la creación de personaje

### DIFF
--- a/CODIGO/ModUtils.bas
+++ b/CODIGO/ModUtils.bas
@@ -698,27 +698,26 @@ Sub IniciarCrearPj()
 
     Dim i As Integer
 
-    frmCrearPersonaje.lstRaza.Clear
 
+    frmCrearPersonaje.lstRaza.Clear
     For i = LBound(ListaRazas()) To UBound(ListaRazas())
         frmCrearPersonaje.lstRaza.AddItem ListaRazas(i)
     Next i
-     frmCrearPersonaje.lstRaza.ListIndex = 0
+    frmCrearPersonaje.lstRaza.ListIndex = 0
+    
     
     frmCrearPersonaje.lstHogar.Clear
     For i = LBound(ListaCiudades()) To UBound(ListaCiudades())
-        frmCrearPersonaje.lstHogar.AddItem (ListaCiudades(i))
+        frmCrearPersonaje.lstHogar.AddItem ListaCiudades(i)
     Next i
-     frmCrearPersonaje.lstHogar.ListIndex = 0
-
+    frmCrearPersonaje.lstHogar.ListIndex = 0
+    
+    
     frmCrearPersonaje.lstProfesion.Clear
-
     For i = LBound(ListaClases()) To UBound(ListaClases())
         frmCrearPersonaje.lstProfesion.AddItem ListaClases(i)
-    
     Next i
     frmCrearPersonaje.lstProfesion.ListIndex = 1
-    
     
         
     MiCabeza = Val(frmCrearPersonaje.Cabeza.List(1))

--- a/CODIGO/TileEngine.bas
+++ b/CODIGO/TileEngine.bas
@@ -651,6 +651,11 @@ Optional ByVal started As Long = -1, Optional ByVal loops As Integer = INFINITE_
         
         grh.Loops = Loops
         grh.speed = GrhData(grhIndex).speed / GrhData(grhIndex).NumFrames
+        
+        If Grh.speed = 0 Then
+            Grh.speed = 1
+        End If
+            
     Else
         grh.Started = 0
         grh.speed = 1

--- a/CODIGO/frmConnect.frm
+++ b/CODIGO/frmConnect.frm
@@ -733,6 +733,7 @@ Private Sub render_MouseUp(Button As Integer, Shift As Integer, x As Single, y A
 
             End If
             
+            
             If x > 415 And x < 431 And y > 277 And y < 295 Then 'ok
                 If frmCrearPersonaje.lstGenero.ListIndex - 1 < 0 Then
                     frmCrearPersonaje.lstGenero.ListIndex = frmCrearPersonaje.lstGenero.ListCount - 1
@@ -742,27 +743,55 @@ Private Sub render_MouseUp(Button As Integer, Shift As Integer, x As Single, y A
                 End If
 
             End If
-       
-            If x > 297 And x < 314 And y > 321 And y < 340 Then 'ok
-    
-                If frmCrearPersonaje.lstHogar.ListIndex < frmCrearPersonaje.lstHogar.ListCount - 1 Then
-                    frmCrearPersonaje.lstHogar.ListIndex = frmCrearPersonaje.lstHogar.ListIndex + 1
-                Else
-                    frmCrearPersonaje.lstHogar.ListIndex = frmCrearPersonaje.lstHogar.ListIndex - 1
-
-                End If
+            
+            ' Hogar
+            ' Shugar: Arreglo los botones para seleccionar el hogar inicial.
+            ' También limito la selección del hogar a Ulla, Nix, Arghal y Forgat.
+            ' El frmCrearPersonaje.lstHogar.ListIndex arranca en 0: Ullathorpe
+            
+            
+            If x > 416 And x < 433 And y > 323 And y < 338 Then
+            
+                ' Botón de la derecha: es el que aumenta el index.
+                ' Si llega al índice máximo (que es el Count-1), vuelve a cero como un buffer circular
+                ' Uso Select Case para saltearme algunas ciudades, me quedo solo con:
+                ' 0: Ulla, 1: Nix, 4: Arghal, 5: Forgat
+                
+                Select Case frmCrearPersonaje.lstHogar.ListIndex
+                    Case 0
+                        frmCrearPersonaje.lstHogar.ListIndex = 1
+                    Case 1
+                        frmCrearPersonaje.lstHogar.ListIndex = 4
+                    Case 4
+                        frmCrearPersonaje.lstHogar.ListIndex = 5
+                    Case 5
+                        frmCrearPersonaje.lstHogar.ListIndex = 0
+                End Select
 
             End If
             
-            If x > 416 And x < 433 And y > 323 And y < 338 Then 'ok
-                If frmCrearPersonaje.lstHogar.ListIndex - 1 < 0 Then
-                    frmCrearPersonaje.lstHogar.ListIndex = frmCrearPersonaje.lstHogar.ListCount - 1
-                Else
-                    frmCrearPersonaje.lstHogar.ListIndex = frmCrearPersonaje.lstHogar.ListIndex - 1
-
-                End If
-
+            
+            If x > 297 And x < 314 And y > 321 And y < 340 Then
+                
+                ' Botón de la izquierda: es el que disminuye el index.
+                ' Si llega al índice 0, pasa al máximo como un buffer circular (que es Count-1)
+                ' Uso Select Case para saltearme algunas ciudades, me quedo solo con:
+                ' 0: Ulla, 1: Nix, 4: Arghal, 5: Forgat
+                
+                Select Case frmCrearPersonaje.lstHogar.ListIndex
+                    Case 0
+                        frmCrearPersonaje.lstHogar.ListIndex = 5
+                    Case 5
+                        frmCrearPersonaje.lstHogar.ListIndex = 4
+                    Case 4
+                        frmCrearPersonaje.lstHogar.ListIndex = 1
+                    Case 1
+                        frmCrearPersonaje.lstHogar.ListIndex = 0
+                End Select
+                
             End If
+
+            
             If x >= 289 And x < 289 + 160 And y >= 525 And y < 525 + 37 Then 'Boton > Volver
                 Call ao20audio.playwav(SND_CLICK)
                 'UserMap = 323

--- a/CODIGO/frmConnect.frm
+++ b/CODIGO/frmConnect.frm
@@ -397,22 +397,21 @@ Private Sub render_MouseUp(Button As Integer, Shift As Integer, x As Single, y A
         
         
         
-        'ciudad
+            ' Hogar inicial
+            ' Shugar: Arreglo los botones para seleccionar el hogar inicial.
         
-            If x > 297 And x < 314 And y > 321 And y < 340 Then 'ok
-    
-                If frmCrearPersonaje.lstHogar.ListIndex < frmCrearPersonaje.lstHogar.ListCount - 1 Then
-                    frmCrearPersonaje.lstHogar.ListIndex = frmCrearPersonaje.lstHogar.ListIndex + 1
-                Else
-                    frmCrearPersonaje.lstHogar.ListIndex = 0
-
-                End If
-
+            If x > 416 And x < 433 And y > 323 And y < 338 Then
+  
+                Call Rotacion_boton_adelante_ciudades
+                
             End If
             
-            If x > 416 And x < 433 And y > 323 And y < 338 Then 'ok
-                frmCrearPersonaje.lstHogar.ListIndex = frmCrearPersonaje.lstHogar.ListCount - 1
+            If x > 297 And x < 314 And y > 321 And y < 340 Then
+            
+                Call Rotacion_boton_atras_ciudades
+                
             End If
+            
             
             If x >= 289 And x < 289 + 160 And y >= 525 And y < 525 + 37 Then 'Boton > Volver
                 Call ao20audio.playwav(SND_CLICK)
@@ -744,50 +743,19 @@ Private Sub render_MouseUp(Button As Integer, Shift As Integer, x As Single, y A
 
             End If
             
-            ' Hogar
+            ' Hogar inicial
             ' Shugar: Arreglo los botones para seleccionar el hogar inicial.
-            ' También limito la selección del hogar a Ulla, Nix, Arghal y Forgat.
-            ' El frmCrearPersonaje.lstHogar.ListIndex arranca en 0: Ullathorpe
-            
             
             If x > 416 And x < 433 And y > 323 And y < 338 Then
             
-                ' Botón de la derecha: es el que aumenta el index.
-                ' Si llega al índice máximo (que es el Count-1), vuelve a cero como un buffer circular
-                ' Uso Select Case para saltearme algunas ciudades, me quedo solo con:
-                ' 0: Ulla, 1: Nix, 4: Arghal, 5: Forgat
-                
-                Select Case frmCrearPersonaje.lstHogar.ListIndex
-                    Case 0
-                        frmCrearPersonaje.lstHogar.ListIndex = 1
-                    Case 1
-                        frmCrearPersonaje.lstHogar.ListIndex = 4
-                    Case 4
-                        frmCrearPersonaje.lstHogar.ListIndex = 5
-                    Case 5
-                        frmCrearPersonaje.lstHogar.ListIndex = 0
-                End Select
+                Call Rotacion_boton_adelante_ciudades
 
             End If
             
             
             If x > 297 And x < 314 And y > 321 And y < 340 Then
                 
-                ' Botón de la izquierda: es el que disminuye el index.
-                ' Si llega al índice 0, pasa al máximo como un buffer circular (que es Count-1)
-                ' Uso Select Case para saltearme algunas ciudades, me quedo solo con:
-                ' 0: Ulla, 1: Nix, 4: Arghal, 5: Forgat
-                
-                Select Case frmCrearPersonaje.lstHogar.ListIndex
-                    Case 0
-                        frmCrearPersonaje.lstHogar.ListIndex = 5
-                    Case 5
-                        frmCrearPersonaje.lstHogar.ListIndex = 4
-                    Case 4
-                        frmCrearPersonaje.lstHogar.ListIndex = 1
-                    Case 1
-                        frmCrearPersonaje.lstHogar.ListIndex = 0
-                End Select
+                Call Rotacion_boton_atras_ciudades
                 
             End If
 
@@ -1029,7 +997,45 @@ render_MouseUp_Err:
 End Sub
 #End If
 
+Private Sub Rotacion_boton_adelante_ciudades()
 
+    ' Shugar - 14/6/24
+    ' Limito la selección del hogar a Ulla, Nix, Arghal y Forgat.
+    ' Botón de la derecha: es el que aumenta el index.
+    ' Implementación de buffer circular, arranca en eCiudad.cUllathorpe
+  
+    Select Case frmCrearPersonaje.lstHogar.ListIndex
+        Case eCiudad.cUllathorpe - 1
+            frmCrearPersonaje.lstHogar.ListIndex = eCiudad.cNix - 1
+        Case eCiudad.cNix - 1
+            frmCrearPersonaje.lstHogar.ListIndex = eCiudad.cArghal - 1
+        Case eCiudad.cArghal - 1
+            frmCrearPersonaje.lstHogar.ListIndex = eCiudad.cForgat - 1
+        Case eCiudad.cForgat - 1
+            frmCrearPersonaje.lstHogar.ListIndex = eCiudad.cUllathorpe - 1
+    End Select
+
+End Sub
+
+Private Sub Rotacion_boton_atras_ciudades()
+    
+    ' Shugar - 14/6/24
+    ' Limito la selección del hogar a Ulla, Nix, Arghal y Forgat.
+    ' Botón de la izquierda: es el que disminuye el index.
+    ' Implementación de buffer circular, arranca en eCiudad.cUllathorpe
+    
+    Select Case frmCrearPersonaje.lstHogar.ListIndex
+        Case eCiudad.cUllathorpe - 1
+            frmCrearPersonaje.lstHogar.ListIndex = eCiudad.cForgat - 1
+        Case eCiudad.cForgat - 1
+            frmCrearPersonaje.lstHogar.ListIndex = eCiudad.cArghal - 1
+        Case eCiudad.cArghal - 1
+            frmCrearPersonaje.lstHogar.ListIndex = eCiudad.cNix - 1
+        Case eCiudad.cNix - 1
+            frmCrearPersonaje.lstHogar.ListIndex = eCiudad.cUllathorpe - 1
+    End Select
+
+End Sub
 
 Private Sub txtNombre_Change()
     


### PR DESCRIPTION
Aceptar primero el PR del server así se actualiza el mapa de Forgat a su nueva ubicación!

Con este PR hago lo siguiente:
1) Dejo como opción de hogar de nacimiento a Ulla, Nix, Arghal y Forgat en la creación de personaje
2) Arreglo los botones para cambiar de ciudad de nacimiento en la creación de personaje
3) Evito que una variable utilizada para graficar grh sea 0, ya que solo aparece solo denominadores y hay casos en los que el cliente intenta dividir por 0
