### PR TITLE
Oculto lbl de oxígeno

### DIFF
--- a/CODIGO/frmMain.frm
+++ b/CODIGO/frmMain.frm
@@ -2988,7 +2988,7 @@ Select Case Index
        ' Label6.Visible = True
         Fuerzalbl.visible = True
         AgilidadLbl.visible = True
-        oxigenolbl.visible = True
+        oxigenolbl.visible = False
         QuestBoton.visible = False
         ImgHogar.visible = False
         ImgEstadisticas.visible = False


### PR DESCRIPTION
Oculto el lbl de oxígeno en frmMain (ya estaba oculto pero faltaba poner en false un valor para que no aparezca luego de ser golpeado o de cambiar al menú y volver a los stats)