### PR TITLE
Sanity check in General_Particle_Create and improved readability

### DIFF
--- a/CODIGO/Graficos_Particulas.bas
+++ b/CODIGO/Graficos_Particulas.bas
@@ -1246,35 +1246,86 @@ General_Char_Particle_Create_Err:
     
 End Function
 
-Public Function General_Particle_Create(ByVal ParticulaInd As Long, ByVal x As Integer, ByVal y As Integer, Optional ByVal particle_life As Long = 0, Optional ByVal noBorrar As Boolean) As Long
-    
+Public Function General_Particle_Create(ByVal ParticulaInd As Long, ByVal x As Integer, ByVal y As Integer, _
+                                        Optional ByVal particle_life As Long = 0, Optional ByVal noBorrar As Boolean) As Long
     On Error GoTo General_Particle_Create_Err
-    
 
-    If ParticulaInd <= 0 Or ParticulaInd > UBound(StreamData) Then Exit Function
+        ' Check if StreamData is initialized by validating array bounds
+10      If LBound(StreamData) > UBound(StreamData) Then
+            Call RegistrarError(0, "StreamData array is not initialized or empty.", "Graficos_Particulas.General_Particle_Create", Erl)
+            Exit Function
+        End If
 
-    Dim rgb_list(0 To 3) As RGBA
+        ' Ensure ParticulaInd is within valid bounds
+20      If ParticulaInd < LBound(StreamData) Or ParticulaInd > UBound(StreamData) Then
+            Call RegistrarError(0, "ParticulaInd out of range: " & ParticulaInd, "Graficos_Particulas.General_Particle_Create", Erl)
+            Exit Function
+        End If
 
-    Call SetRGBA(rgb_list(0), StreamData(ParticulaInd).colortint(0).B, StreamData(ParticulaInd).colortint(0).G, StreamData(ParticulaInd).colortint(0).R)
-    Call SetRGBA(rgb_list(1), StreamData(ParticulaInd).colortint(1).B, StreamData(ParticulaInd).colortint(1).G, StreamData(ParticulaInd).colortint(1).R)
-    Call SetRGBA(rgb_list(2), StreamData(ParticulaInd).colortint(2).B, StreamData(ParticulaInd).colortint(2).G, StreamData(ParticulaInd).colortint(2).R)
-    Call SetRGBA(rgb_list(3), StreamData(ParticulaInd).colortint(3).B, StreamData(ParticulaInd).colortint(3).G, StreamData(ParticulaInd).colortint(3).R)
+        ' Ensure colortint array exists and has at least 4 elements
+30      If LBound(StreamData(ParticulaInd).colortint) > UBound(StreamData(ParticulaInd).colortint) Or UBound(StreamData(ParticulaInd).colortint) < 3 Then
+            Call RegistrarError(0, "StreamData(" & ParticulaInd & ").colortint array out of bounds", "Graficos_Particulas.General_Particle_Create", Erl)
+            Exit Function
+        End If
 
-    General_Particle_Create = Graficos_Particulas.Particle_Group_Create(x, y, StreamData(ParticulaInd).grh_list, rgb_list(), StreamData(ParticulaInd).NumOfParticles, ParticulaInd, _
-       StreamData(ParticulaInd).AlphaBlend, IIf(particle_life = 0, StreamData(ParticulaInd).life_counter, particle_life), StreamData(ParticulaInd).speed, , StreamData(ParticulaInd).x1, StreamData(ParticulaInd).y1, StreamData(ParticulaInd).Angle, _
-       StreamData(ParticulaInd).vecx1, StreamData(ParticulaInd).vecx2, StreamData(ParticulaInd).vecy1, StreamData(ParticulaInd).vecy2, _
-       StreamData(ParticulaInd).life1, StreamData(ParticulaInd).life2, StreamData(ParticulaInd).friction, StreamData(ParticulaInd).spin_speedL, _
-       StreamData(ParticulaInd).gravity, StreamData(ParticulaInd).grav_strength, StreamData(ParticulaInd).bounce_strength, StreamData(ParticulaInd).x2, _
-       StreamData(ParticulaInd).y2, StreamData(ParticulaInd).XMove, StreamData(ParticulaInd).move_x1, StreamData(ParticulaInd).move_x2, StreamData(ParticulaInd).move_y1, _
-       StreamData(ParticulaInd).move_y2, StreamData(ParticulaInd).YMove, StreamData(ParticulaInd).spin_speedH, StreamData(ParticulaInd).spin, StreamData(ParticulaInd).grh_resize, StreamData(ParticulaInd).grh_resizex, StreamData(ParticulaInd).grh_resizey, noBorrar)
+        ' Declare RGBA list
+40      Dim rgb_list(0 To 3) As RGBA
 
-    
+        ' Assign colors safely
+50      Call SetRGBA(rgb_list(0), StreamData(ParticulaInd).colortint(0).B, StreamData(ParticulaInd).colortint(0).G, StreamData(ParticulaInd).colortint(0).R)
+60      Call SetRGBA(rgb_list(1), StreamData(ParticulaInd).colortint(1).B, StreamData(ParticulaInd).colortint(1).G, StreamData(ParticulaInd).colortint(1).R)
+70      Call SetRGBA(rgb_list(2), StreamData(ParticulaInd).colortint(2).B, StreamData(ParticulaInd).colortint(2).G, StreamData(ParticulaInd).colortint(2).R)
+80      Call SetRGBA(rgb_list(3), StreamData(ParticulaInd).colortint(3).B, StreamData(ParticulaInd).colortint(3).G, StreamData(ParticulaInd).colortint(3).R)
+
+        ' Extract key properties
+        Dim particleCount As Long: particleCount = StreamData(ParticulaInd).NumOfParticles
+        Dim alphaBlend As Boolean: alphaBlend = StreamData(ParticulaInd).AlphaBlend
+        Dim aliveCounter As Long: aliveCounter = IIf(particle_life = 0, StreamData(ParticulaInd).life_counter, particle_life)
+        Dim frameSpeed As Single: frameSpeed = StreamData(ParticulaInd).speed
+        Dim id As Long: id = ParticulaInd
+        Dim x1 As Integer: x1 = StreamData(ParticulaInd).x1
+        Dim y1 As Integer: y1 = StreamData(ParticulaInd).y1
+        Dim angle As Integer: angle = StreamData(ParticulaInd).Angle
+        Dim vecx1 As Integer: vecx1 = StreamData(ParticulaInd).vecx1
+        Dim vecx2 As Integer: vecx2 = StreamData(ParticulaInd).vecx2
+        Dim vecy1 As Integer: vecy1 = StreamData(ParticulaInd).vecy1
+        Dim vecy2 As Integer: vecy2 = StreamData(ParticulaInd).vecy2
+        Dim life1 As Integer: life1 = StreamData(ParticulaInd).life1
+        Dim life2 As Integer: life2 = StreamData(ParticulaInd).life2
+        Dim friction As Integer: friction = StreamData(ParticulaInd).friction
+        Dim spinSpeedL As Single: spinSpeedL = StreamData(ParticulaInd).spin_speedL
+        Dim gravity As Boolean: gravity = StreamData(ParticulaInd).gravity
+        Dim gravStrength As Long: gravStrength = StreamData(ParticulaInd).grav_strength
+        Dim bounceStrength As Long: bounceStrength = StreamData(ParticulaInd).bounce_strength
+        Dim x2 As Integer: x2 = StreamData(ParticulaInd).x2
+        Dim y2 As Integer: y2 = StreamData(ParticulaInd).y2
+        Dim xMove As Boolean: xMove = StreamData(ParticulaInd).XMove
+        Dim moveX1 As Integer: moveX1 = StreamData(ParticulaInd).move_x1
+        Dim moveX2 As Integer: moveX2 = StreamData(ParticulaInd).move_x2
+        Dim moveY1 As Integer: moveY1 = StreamData(ParticulaInd).move_y1
+        Dim moveY2 As Integer: moveY2 = StreamData(ParticulaInd).move_y2
+        Dim yMove As Boolean: yMove = StreamData(ParticulaInd).YMove
+        Dim spinSpeedH As Single: spinSpeedH = StreamData(ParticulaInd).spin_speedH
+        Dim spin As Boolean: spin = StreamData(ParticulaInd).spin
+        Dim grhResize As Boolean: grhResize = StreamData(ParticulaInd).grh_resize
+        Dim grhResizeX As Integer: grhResizeX = StreamData(ParticulaInd).grh_resizex
+        Dim grhResizeY As Integer: grhResizeY = StreamData(ParticulaInd).grh_resizey
+
+90      General_Particle_Create = Graficos_Particulas.Particle_Group_Create( _
+            x, y, StreamData(ParticulaInd).grh_list, rgb_list(), _
+            particleCount, id, alphaBlend, aliveCounter, frameSpeed, , _
+            x1, y1, angle, vecx1, vecx2, vecy1, vecy2, life1, life2, _
+            friction, spinSpeedL, gravity, gravStrength, bounceStrength, _
+            x2, y2, xMove, moveX1, moveX2, moveY1, moveY2, yMove, _
+            spinSpeedH, spin, grhResize, grhResizeX, grhResizeY, noBorrar _
+        )
+
     Exit Function
 
 General_Particle_Create_Err:
-    Call RegistrarError(Err.Number, Err.Description, "Graficos_Particulas.General_Particle_Create", Erl)
-    Resume Next
-    
+110     Call RegistrarError(Err.Number, Err.Description & " | ParticulaInd: " & ParticulaInd, "Graficos_Particulas.General_Particle_Create", Erl)
+        Resume Next
+
 End Function
 
 Public Function Char_Particle_Group_Create(ByVal char_index As Integer, ByRef grh_index_list() As Long, ByRef rgb_list() As RGBA, _


### PR DESCRIPTION
This pull request includes significant changes to the `General_Particle_Create` function in the `CODIGO/Graficos_Particulas.bas` file to improve error handling and code clarity. The changes ensure that array bounds are checked before accessing elements and that key properties are extracted and assigned more safely.

Improvements to error handling and code clarity:

* [`CODIGO/Graficos_Particulas.bas`](diffhunk://#diff-2c6c384e5848a397cf61df2a088e736ee56dac4bd4dca8a7bc1742738eafe393L1249-R1326): Added checks to ensure the `StreamData` array is initialized and non-empty before proceeding with operations.
* [`CODIGO/Graficos_Particulas.bas`](diffhunk://#diff-2c6c384e5848a397cf61df2a088e736ee56dac4bd4dca8a7bc1742738eafe393L1249-R1326): Added bounds checking for `ParticulaInd` to ensure it is within valid limits.
* [`CODIGO/Graficos_Particulas.bas`](diffhunk://#diff-2c6c384e5848a397cf61df2a088e736ee56dac4bd4dca8a7bc1742738eafe393L1249-R1326): Added checks to ensure the `colortint` array exists and has at least four elements before accessing it.
* [`CODIGO/Graficos_Particulas.bas`](diffhunk://#diff-2c6c384e5848a397cf61df2a088e736ee56dac4bd4dca8a7bc1742738eafe393L1249-R1326): Extracted and assigned key properties from `StreamData(ParticulaInd)` to local variables for better readability and maintainability.
* [`CODIGO/Graficos_Particulas.bas`](diffhunk://#diff-2c6c384e5848a397cf61df2a088e736ee56dac4bd4dca8a7bc1742738eafe393L1249-R1326): Enhanced error logging to include `ParticulaInd` in the error description for better debugging.