### PR TITLE
Actualizar nombre del mapa al conectarse

### DIFF
--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -571,7 +571,8 @@ On Error GoTo HandleLogged_Err
     frmMain.oxigenolbl.visible = True
     frmMain.imgDeleteItem.visible = True
     frmMain.oxigenolbl.visible = False
-
+    Call NameMapa(ResourceMap)
+    
      lFrameTimer = 0
      FramesPerSecCounter = 0
     


### PR DESCRIPTION
Cuando te conectas con un personaje en la cuenta por primera vez, el label que indica en que mapa estas aparece como "Mapa desconocido", o al cambiar el personaje, el label aparece con el nombre del mapa del anterior usuario que estaba conectado en esa cuenta. Este no se actualiza hasta cambiar de mapa. Esta linea lo que hace es actualizar ese label para que al entrar se muestre correctamente.