### PR TITLE
Mostrar clase requerida para iniciar quest

### DIFF
--- a/CODIGO/ModUtils.bas
+++ b/CODIGO/ModUtils.bas
@@ -130,7 +130,7 @@ Public Type tQuest
     NextQuest As String
     DescFinal As String
     RequiredLevel As Byte
-    
+    RequiredClass As Integer
     RequiredQuest As Byte
     
     RequiredOBJs As Byte

--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -7382,6 +7382,7 @@ Public Sub HandleNpcQuestListSend()
                               
             QuestList(QuestIndex).RequiredLevel = Reader.ReadInt8
             QuestList(QuestIndex).RequiredQuest = Reader.ReadInt16
+            QuestList(QuestIndex).RequiredClass = Reader.ReadInt8
             
             tmpByte = Reader.ReadInt8
     

--- a/CODIGO/frmQuestInfo.frm
+++ b/CODIGO/frmQuestInfo.frm
@@ -589,13 +589,25 @@ Private Sub ListViewQuest_ItemClick(ByVal Item As MSComctlLib.ListItem)
         objetolbl.Caption = ""
         
         lblRepetible.Visible = QuestList(QuestIndex).Repetible = 1
-        If QuestList(QuestIndex).RequiredQuest <> 0 Then
-            FrmQuestInfo.Text1.Text = ""
-            Call AddtoRichTextBox(Text1, QuestList(QuestIndex).desc & vbCrLf & vbCrLf & "Requisitos: " & vbCrLf & "Nivel requerido: " & QuestList(QuestIndex).RequiredLevel & vbCrLf & "Quest: " & QuestList(QuestList(QuestIndex).RequiredQuest).nombre, 128, 128, 128)
-        Else
-            FrmQuestInfo.Text1.Text = ""
-            Call AddtoRichTextBox(Text1, QuestList(QuestIndex).desc & vbCrLf & vbCrLf & "Requisitos: " & vbCrLf & "Nivel requerido: " & QuestList(QuestIndex).RequiredLevel, 128, 128, 128)
+        
+        If QuestList(QuestIndex).RequiredClass <> 0 And QuestList(QuestIndex).RequiredClass <= 12 Then 'Si tiene clase requerida, lo muestra en requisitos, lo limito a 12 que son el num de clases para evitar conflictos en caso de que por error pongan un número mayor
+            If QuestList(QuestIndex).RequiredQuest <> 0 Then
+                FrmQuestInfo.Text1.Text = ""
+                Call AddtoRichTextBox(Text1, QuestList(QuestIndex).desc & vbCrLf & vbCrLf & "Requisitos: " & vbCrLf & "Clase: " & ListaClases(QuestList(QuestIndex).RequiredClass) & vbCrLf & "Nivel requerido: " & QuestList(QuestIndex).RequiredLevel & vbCrLf & "Quest: " & QuestList(QuestList(QuestIndex).RequiredQuest).nombre, 128, 128, 128)
+            Else
+                FrmQuestInfo.Text1.Text = ""
+                Call AddtoRichTextBox(Text1, QuestList(QuestIndex).desc & vbCrLf & vbCrLf & "Requisitos: " & vbCrLf & "Clase: " & ListaClases(QuestList(QuestIndex).RequiredClass) & vbCrLf & "Nivel requerido: " & QuestList(QuestIndex).RequiredLevel, 128, 128, 128)
+            End If
+        Else 'Si NO tiene clase requerida, NO lo muestra en requisitos
+            If QuestList(QuestIndex).RequiredQuest <> 0 Then
+                FrmQuestInfo.Text1.Text = ""
+                Call AddtoRichTextBox(Text1, QuestList(QuestIndex).desc & vbCrLf & vbCrLf & "Requisitos: " & vbCrLf & "Nivel requerido: " & QuestList(QuestIndex).RequiredLevel & vbCrLf & "Quest: " & QuestList(QuestList(QuestIndex).RequiredQuest).nombre, 128, 128, 128)
+            Else
+                FrmQuestInfo.Text1.Text = ""
+                Call AddtoRichTextBox(Text1, QuestList(QuestIndex).desc & vbCrLf & vbCrLf & "Requisitos: " & vbCrLf & "Nivel requerido: " & QuestList(QuestIndex).RequiredLevel, 128, 128, 128)
+            End If
         End If
+        
         If QuestList(QuestIndex).RequiredSkill.SkillType > 0 Then
             Call AddtoRichTextBox(Text1, SkillsNames(QuestList(QuestIndex).RequiredSkill.SkillType) & ": " & QuestList(QuestIndex).RequiredSkill.RequiredValue & vbCrLf, 128, 128, 128)
         End If

--- a/CODIGO/frmQuestInfo.frm
+++ b/CODIGO/frmQuestInfo.frm
@@ -590,23 +590,25 @@ Private Sub ListViewQuest_ItemClick(ByVal Item As MSComctlLib.ListItem)
         
         lblRepetible.Visible = QuestList(QuestIndex).Repetible = 1
         
-        If QuestList(QuestIndex).RequiredClass <> 0 And QuestList(QuestIndex).RequiredClass <= 12 Then 'Si tiene clase requerida, lo muestra en requisitos, lo limito a 12 que son el num de clases para evitar conflictos en caso de que por error pongan un número mayor
-            If QuestList(QuestIndex).RequiredQuest <> 0 Then
-                FrmQuestInfo.Text1.Text = ""
-                Call AddtoRichTextBox(Text1, QuestList(QuestIndex).desc & vbCrLf & vbCrLf & "Requisitos: " & vbCrLf & "Clase: " & ListaClases(QuestList(QuestIndex).RequiredClass) & vbCrLf & "Nivel requerido: " & QuestList(QuestIndex).RequiredLevel & vbCrLf & "Quest: " & QuestList(QuestList(QuestIndex).RequiredQuest).nombre, 128, 128, 128)
-            Else
-                FrmQuestInfo.Text1.Text = ""
-                Call AddtoRichTextBox(Text1, QuestList(QuestIndex).desc & vbCrLf & vbCrLf & "Requisitos: " & vbCrLf & "Clase: " & ListaClases(QuestList(QuestIndex).RequiredClass) & vbCrLf & "Nivel requerido: " & QuestList(QuestIndex).RequiredLevel, 128, 128, 128)
+        With QuestList(QuestIndex)
+            If .RequiredClass <> 0 And .RequiredClass <= 12 Then 'Si tiene clase requerida, lo muestra en requisitos, lo limito a 12 que son el num de clases para evitar conflictos en caso de que por error pongan un número mayor
+                If .RequiredQuest <> 0 Then
+                    FrmQuestInfo.Text1.Text = ""
+                    Call AddtoRichTextBox(Text1, .desc & vbCrLf & vbCrLf & "Requisitos: " & vbCrLf & "Clase: " & ListaClases(.RequiredClass) & vbCrLf & "Nivel requerido: " & .RequiredLevel & vbCrLf & "Quest: " & QuestList(.RequiredQuest).nombre, 128, 128, 128)
+                Else
+                    FrmQuestInfo.Text1.Text = ""
+                    Call AddtoRichTextBox(Text1, .desc & vbCrLf & vbCrLf & "Requisitos: " & vbCrLf & "Clase: " & ListaClases(.RequiredClass) & vbCrLf & "Nivel requerido: " & .RequiredLevel, 128, 128, 128)
+                End If
+            Else 'Si NO tiene clase requerida, NO lo muestra en requisitos
+            If .RequiredQuest <> 0 Then
+                    FrmQuestInfo.Text1.Text = ""
+                    Call AddtoRichTextBox(Text1, .desc & vbCrLf & vbCrLf & "Requisitos: " & vbCrLf & "Nivel requerido: " & .RequiredLevel & vbCrLf & "Quest: " & QuestList(.RequiredQuest).nombre, 128, 128, 128)
+                Else
+                    FrmQuestInfo.Text1.Text = ""
+                    Call AddtoRichTextBox(Text1, .desc & vbCrLf & vbCrLf & "Requisitos: " & vbCrLf & "Nivel requerido: " & .RequiredLevel, 128, 128, 128)
+                End If
             End If
-        Else 'Si NO tiene clase requerida, NO lo muestra en requisitos
-            If QuestList(QuestIndex).RequiredQuest <> 0 Then
-                FrmQuestInfo.Text1.Text = ""
-                Call AddtoRichTextBox(Text1, QuestList(QuestIndex).desc & vbCrLf & vbCrLf & "Requisitos: " & vbCrLf & "Nivel requerido: " & QuestList(QuestIndex).RequiredLevel & vbCrLf & "Quest: " & QuestList(QuestList(QuestIndex).RequiredQuest).nombre, 128, 128, 128)
-            Else
-                FrmQuestInfo.Text1.Text = ""
-                Call AddtoRichTextBox(Text1, QuestList(QuestIndex).desc & vbCrLf & vbCrLf & "Requisitos: " & vbCrLf & "Nivel requerido: " & QuestList(QuestIndex).RequiredLevel, 128, 128, 128)
-            End If
-        End If
+        End With
         
         If QuestList(QuestIndex).RequiredSkill.SkillType > 0 Then
             Call AddtoRichTextBox(Text1, SkillsNames(QuestList(QuestIndex).RequiredSkill.SkillType) & ": " & QuestList(QuestIndex).RequiredSkill.RequiredValue & vbCrLf, 128, 128, 128)


### PR DESCRIPTION
Este cambio muestra la clase requerida para iniciar una quest a través de RequiredClass en quest.dat

Necesario para que funcione: https://github.com/ao-org/argentum-online-server/pull/721