### PR TITLE
Desactivo contadores si el usuario está muerto

### DIFF
--- a/CODIGO/frmMain.frm
+++ b/CODIGO/frmMain.frm
@@ -1899,7 +1899,12 @@ Private Sub Contadores_Timer()
     On Error GoTo Contadores_Timer_Err
     
 
-    If UserStats.estado = 1 Then Exit Sub
+    'Si el usuario está muerto, desactiva los contadores
+    If UserStats.estado = 1 Then
+        Contadores.enabled = False
+        Exit Sub
+    End If
+    
     If InviCounter > 0 Then
         InviCounter = InviCounter - 1
 


### PR DESCRIPTION
Si el usuario está muerto se desactivan los contadores, de esta forma luego de revivir no vuelven a aparecer hasta que se dope nuevamente.