### PR TITLE
DPLAY fixed duplicated Login messages

### DIFF
--- a/CODIGO/clsNetWriter.cls
+++ b/CODIGO/clsNetWriter.cls
@@ -53,7 +53,7 @@ On Error GoTo send_error:
 #If Developer = 1 Then
     Call SaveStringInFile("Sending:" & ByteArrayToDecimalString(oMsg), "send_debug.txt")
 #End If
-    dpc.send oMsg, 0, DPNSEND_GUARANTEED Or DPNSEND_NOLOOPBACK Or DPNSEND_PRIORITY_HIGH Or DPNSEND_NOCOMPLETE Or DPNSEND_SYNC
+    dpc.send oMsg, 0, DPNSEND_GUARANTEED Or DPNSEND_NOLOOPBACK Or DPNSEND_PRIORITY_HIGH
     Me.Clear
     Exit Sub
 send_error:

--- a/CODIGO/modNetwork.bas
+++ b/CODIGO/modNetwork.bas
@@ -205,7 +205,6 @@ On Error GoTo OnClientConnect_Err:
     Err.Clear
     Connected = True
     Unload frmConnecting
-    Call Login
     Exit Sub
 OnClientConnect_Err:
    If Err.Number <> 0 Then


### PR DESCRIPTION
When using DPLAY, the client was sending two commands with eLoginExistingChar.

Solved by removing the call to Login when we get the event ConnectionComplete