### PR TITLE
Arreglo de conteo en quest: muestra "OK" al alcanzar o superar la cantidad de npcs requeridos

### DIFF
--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -7190,11 +7190,10 @@ Private Sub HandleQuestDetails()
 
                     cantok = cantidadnpc - matados
                        
-                    If cantok = 0 Then
-                        subelemento.SubItems(1) = "OK"
-                    Else
+                    If cantok > 0 Then
                         subelemento.SubItems(1) = matados & "/" & cantidadnpc
-
+                    Else
+                        subelemento.SubItems(1) = "OK"
                     End If
                         
                     ' subelemento.SubItems(1) = cantidadnpc - matados


### PR DESCRIPTION
Actualmente cuando se quiere ver cuántos npcs llevas matado en la quest, si mataste más de los requeridos, se muestra 11/10 por ejemplo. Esto sucede porque el condicional es si la cantidad es = a 0. Como el cálculo que se hace es cantidadnpc - matados = cantidad, si mataste más npcs de los requeridos, el valor de cantidad da -1 y de esa forma entra directamente en el Else, mostrando como resultado un número mayor de npcs matados que los requeridos (11/10 por ejemplo). Con este cambio al matar los npcs requeridos o más, entra correctamente en el Else y se muestra el OK correspondiente.