### PR TITLE
Commented out exp/gold tracker until is fixed

### DIFF
--- a/CODIGO/frmMain.frm
+++ b/CODIGO/frmMain.frm
@@ -1715,8 +1715,8 @@ Private Sub loadButtons()
                                                 "boton-mao-over.bmp", _
                                                 "boton-mao-off.bmp", Me)
                                                 
-    'Loading exp and gold tracker buttons
-    handleGoldNExpTrackerPictureLogic
+    ' Loading exp and gold tracker buttons
+    ' handleGoldNExpTrackerPictureLogic
      
 End Sub
 
@@ -4540,8 +4540,8 @@ Private Sub Form_MouseMove(Button As Integer, Shift As Integer, x As Single, y A
         Retar.Tag = "0"
     End If
     
-'Metodo para actualizar la imagen del tracker de oro y experiencia
-    Call handleGoldNExpTrackerPictureLogic
+   'Metodo para actualizar la imagen del tracker de oro y experiencia
+   ' Call handleGoldNExpTrackerPictureLogic
 
 
     MenuUser.LostFocus


### PR DESCRIPTION
This pull request includes changes to the `CODIGO/frmMain.frm` file, specifically commenting out the calls to the `handleGoldNExpTrackerPictureLogic` method in two places. This change appears to be aimed at temporarily disabling the logic related to updating the gold and experience tracker images.

The most important changes include:

* [`Private Sub loadButtons()`](diffhunk://#diff-26b9550687feec6c69ceaf6dbfb8b53e1ff77dda0c272381c8a5823e870d8b0fL1719-R1719): Commented out the call to `handleGoldNExpTrackerPictureLogic` to disable the gold and experience tracker picture logic.
* `Private Sub Form_MouseMove(Button As Integer, Shift As Integer, x As Single, y A)`: Commented out the call to `handleGoldNExpTrackerPictureLogic` to prevent the tracker picture logic from being executed on mouse move events.