### PR TITLE
Fix: Limpieza del PlayerView al seleccionar mapa sin NPC

### DIFF
--- a/CODIGO/frmMapaGrande.frm
+++ b/CODIGO/frmMapaGrande.frm
@@ -816,6 +816,7 @@ Private Sub picMap_MouseDown(Button As Integer, Shift As Integer, x As Single, y
     Label4.Caption = ""
     Label5.Caption = ""
     Label9.Caption = ""
+    Me.PlayerView.Cls 'Limpia el PictureBox que muestra al npc
     listdrop.ListItems.Clear
     
     ListView1.SetFocus


### PR DESCRIPTION
Este cambio soluciona un bug en el que el PlayerView que muestra los npcs en el mapa no se limpiaba correctamente al clickear un mapa sin NPCs. La función picMap_MouseDown ahora se encarga de limpiar el contenido de PlayerView utilizando Me.PlayerView.Cls cuando el nuevo mapa seleccionado no tiene NPCs. Esto asegura que el PictureBox no quede con el dibujo del NPC anterior.