### PR TITLE
Changed gold mao price

### DIFF
--- a/Languages/1.json
+++ b/Languages/1.json
@@ -154,7 +154,7 @@
     "MENSAJE_VALOR_PERSONAJE_INVALIDO": "El valor ingresado del personaje es inválido.",
     "MENSAJE_PUBLICAR_PERSONAJE": "Estás publicando a ",
     "MENSAJE_PUBLICAR_PERSONAJE_VALOR": " a un valor de ",
-    "MENSAJE_PUBLICAR_PERSONAJE_COSTO": ", se descontarán las 20.000 monedas de oro. En caso de querer cancelar la misma deberás hacerlo desde la página web.",
+    "MENSAJE_PUBLICAR_PERSONAJE_COSTO": ", se descontarán las 35.000 monedas de oro. En caso de querer cancelar la misma deberás hacerlo desde la página web.",
     "MENSAJE_TITULO_PUBLICAR_PERSONAJE": "Publicar personaje",
     "MENSAJE_ERROR_DIRECTX": "Error fatal al crear el objeto DirectX8.",
     "MENSAJE_ERROR_DIRECTD3D": "Error fatal al crear el objeto DirectD3D.",

--- a/Languages/2.json
+++ b/Languages/2.json
@@ -154,7 +154,7 @@
     "MENSAJE_VALOR_PERSONAJE_INVALIDO": "The entered character value is invalid.",
     "MENSAJE_PUBLICAR_PERSONAJE": "You are listing ",
     "MENSAJE_PUBLICAR_PERSONAJE_VALOR": " at a value of ",
-    "MENSAJE_PUBLICAR_PERSONAJE_COSTO": ", 20,000 gold coins will be deducted. If you want to cancel it, you must do so from the website.",
+    "MENSAJE_PUBLICAR_PERSONAJE_COSTO": ", 35,000 gold coins will be deducted. If you want to cancel it, you must do so from the website.",
     "MENSAJE_TITULO_PUBLICAR_PERSONAJE": "Publish Character",
     "MENSAJE_ERROR_DIRECTX": "Fatal error creating DirectX8 object.",
     "MENSAJE_ERROR_DIRECTD3D": "Fatal error creating DirectD3D object.",


### PR DESCRIPTION
This pull request updates the cost associated with publishing a character in the application. The changes ensure consistency across different language files by increasing the deduction amount from 20,000 to 35,000 gold coins.

Localization updates:

* [`Languages/1.json`](diffhunk://#diff-c095816dc41d76343121e4679e7617b5f474b5b2549e82ac564ad70f21e49274L157-R157): Updated the Spanish localization for `MENSAJE_PUBLICAR_PERSONAJE_COSTO` to reflect the new deduction amount of 35,000 gold coins.
* [`Languages/2.json`](diffhunk://#diff-aa7a86f241871d4083a745fd57eff4ba5b391a47536fb893cd8ec8d7af24f74cL157-R157): Updated the English localization for `MENSAJE_PUBLICAR_PERSONAJE_COSTO` to reflect the new deduction amount of 35,000 gold coins.