### PR TITLE
Default language the same as OS language

### DIFF
--- a/CODIGO/ModLanguage.bas
+++ b/CODIGO/ModLanguage.bas
@@ -69,14 +69,13 @@ DirLanguage_Err:
 End Function
 
 Public Sub SetLanguageApplication()
-    On Error GoTo ErrorHandler
-
+On Error GoTo ErrorHandler
+    
     Dim Localization As String
     Dim LangFilePath As String
     Dim LangFileContent As String
-
     ' Retrieve localization setting
-    Localization = GetSetting("OPCIONES", "Localization")
+    Localization = GetSetting("OPCIONES", "Language")
 
     ' If no localization is set, determine the default language based on system locale
     If Len(Localization) = 0 Then
@@ -90,7 +89,7 @@ Public Sub SetLanguageApplication()
                 language = e_language.English
         End Select
         ' Save the determined language as the default localization setting
-        SaveSetting "OPCIONES", "Localization", language
+        SaveSetting "OPCIONES", "Language", language
     Else
         ' Use the stored localization setting
         language = Localization

--- a/CODIGO/ModSettings.bas
+++ b/CODIGO/ModSettings.bas
@@ -39,9 +39,6 @@ End Function
 Public Function GetSetting(ByVal Section As String, ByVal Name As String) As String
     Dim currentValue As String
     currentValue = GetVar(App.path & CustomSettingsFile, Section, Name)
-    If currentValue = "" Then
-        currentValue = GetVar(App.path & DefaultSettingsFile, Section, Name)
-    End If
     GetSetting = currentValue
 End Function
 


### PR DESCRIPTION
* Changed the field Localization to Language
* Removed the reading settings from DefaultSettingsFile when the key is not found in CustomSettingsFile aka configuracion.ini. There should be a single configuration file. The custom settings file is causing confusion.