### PR TITLE
Agrego mensaje EMPTY_LABEL a JsonLanguage (1.json y 2.json)

### DIFF
--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -4382,9 +4382,9 @@ Private Sub HandleChangeSpellSlot()
         End If
     Else
         If Slot <= hlst.ListCount Then
-            hlst.List(Slot - 1) = "(Vacio)"
+            hlst.List(Slot - 1) = JsonLanguage.Item("EMPTY_LABEL")
         Else
-            Call hlst.AddItem("(Vacio)")
+            Call hlst.AddItem(JsonLanguage.Item("EMPTY_LABEL"))
             hlst.Scroll = LastScroll
         End If
     End If

--- a/Languages/1.json
+++ b/Languages/1.json
@@ -583,5 +583,7 @@
     "FORM_OPCION_23": "CARCEL",
     "FORM_OPCION_24": "BAN",
     "DAMAGE": "Daño: ",
-    "DEFENSE": "Defensa: "
+    "DEFENSE": "Defensa: ",
+	"EMPTY_LABEL": "(Vacío)"
+
 }

--- a/Languages/2.json
+++ b/Languages/2.json
@@ -583,5 +583,6 @@
     "FORM_OPCION_23": "JAIL",
     "FORM_OPCION_24": "BAN",
     "DAMAGE": "Damage: ",
-    "DEFENSE": "Defense: "
+    "DEFENSE": "Defense: ",
+	"EMPTY_LABEL": "(Empty)"
 }


### PR DESCRIPTION
Cambios realizados:
Se añadió "EMPTY_LABEL": "(Vacío)" en 1.json (Español).

Se añadió "EMPTY_LABEL": "(Empty)" en 2.json (Inglés).

Uso del ID JsonLanguage.Item("EMPTY_LABEL") en el cliente.