### PR TITLE
fix_kickuninvitedhouseguests client-side

### DIFF
--- a/CODIGO/PacketId.bas
+++ b/CODIGO/PacketId.bas
@@ -535,6 +535,7 @@ Public Enum ClientPacketID
     eUseHKeySlot
     eAntiCheatMessage
     eRequestLobbyList
+    eKickUninvitedHouseGuests '/KICKUNINVITEDHOUSEGUESTS
     #If PYMMO = 0 Then
     eCreateAccount
     eLoginAccount

--- a/CODIGO/ProtocolCmdParse.bas
+++ b/CODIGO/ProtocolCmdParse.bas
@@ -2113,6 +2113,10 @@ Public Sub ParseUserCommand(ByVal RawCommand As String)
                 Call HandleReqDebugCmd(ArgumentosAll, CantidadArgumentos)
             Case "/FEATURETOGGLE"
                 Call HandleFeatureToggle(ArgumentosAll, CantidadArgumentos)
+            Case "/KICKUNINVITEDHOUSEGUESTS"
+                If EsGM Then
+                        Call WriteKickUninvitedHouseGuests()
+                End If
             Case Else
                 Call ShowConsoleMsg(JsonLanguage.Item("MENSAJE_COMANDO_INVALIDO"))
 

--- a/CODIGO/Protocol_Writes.bas
+++ b/CODIGO/Protocol_Writes.bas
@@ -6723,3 +6723,12 @@ WriteAntiCheatMessage_Err:
         Call RegistrarError(Err.Number, Err.Description, "Argentum20.Protocol_Writes.WriteAntiCheatMessage", Erl)
 End Sub
 
+Public Sub WriteKickUninvitedHouseGuests()
+    On Error GoTo WriteKickUninvitedHouseGuests_Err
+        Call Writer.WriteInt16(ClientPacketID.eKickUninvitedHouseGuests)
+        Call modNetwork.Send(Writer)
+        Exit Sub
+WriteKickUninvitedHouseGuests_Err:
+        Call Writer.Clear
+        Call RegistrarError(Err.Number, Err.Description, "Argentum20.Protocol_Writes.WriteKickUninvitedHouseGuests", Erl)
+End Sub


### PR DESCRIPTION
-Added a command protocol to match the server side
-the command enables game masters to kick people residing inside patreon houses directly using the database