### PR TITLE
Mascots don't make noise when walking

### DIFF
--- a/CODIGO/TileEngine.bas
+++ b/CODIGO/TileEngine.bas
@@ -741,6 +741,9 @@ Sub DoPasosFx(ByVal charindex As Integer)
    
     With charlist(CharIndex)
 
+        ' Mascots don't make noise
+        If .EsMascota Then Exit Sub
+
         If EstaPCarea(CharIndex) And Not .Muerto And .priv <= charlist(UserCharIndex).priv And charlist(UserCharIndex).Muerto = False Then
             .Pie = Not .Pie
             


### PR DESCRIPTION
At the request of users, it was decided to remove footstep sounds from NPCs that are pets or summons. The goal is to reduce the noise they make when walking all at once, which makes it difficult to hear invisible players.