### PR TITLE
WIP soporte-wav-multilenguaje

### DIFF
--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -3439,11 +3439,26 @@ On Error GoTo HandlePlayWave_Err
     Dim srcX As Byte
     Dim srcY As Byte
     Dim cancelLastWave As Byte
-    
+    Dim Localize As Byte
+    Dim filename As String
+    Dim prefixed_filename As String
+    Dim unprefixed_filename As String
+        
     wave = Reader.ReadInt16()
     srcX = Reader.ReadInt8()
     srcY = Reader.ReadInt8()
     cancelLastWave = Reader.ReadInt8()
+    Localize = Reader.ReadInt8()
+    
+    If Localize = 1 Then
+        Dim langPrefix As String
+        langPrefix = GetLanguagePrefix(currentLanguage)
+        filename = langPrefix & "_" & CStr(wave) & ".wav"
+    Else
+        
+        filename = CStr(wave) & ".wav"
+        
+    End If
     
     If wave = 400 And MapDat.niebla = 0 Then Exit Sub
     If wave = 401 And MapDat.niebla = 0 Then Exit Sub
@@ -3451,19 +3466,20 @@ On Error GoTo HandlePlayWave_Err
     If wave = 403 And MapDat.niebla = 0 Then Exit Sub
     If wave = 404 And MapDat.niebla = 0 Then Exit Sub
     
+    
     If cancelLastWave Then
-        Call ao20audio.StopWav(CStr(wave))
+        Call ao20audio.StopWav(filename)
         If cancelLastWave = 2 Then Exit Sub
     End If
     
     If srcX = 0 Or srcY = 0 Then
-        Call ao20audio.PlayWav(CStr(wave), False, 0, 0)
+        Call ao20audio.PlayWav(filename, False, 0, 0)
     Else
         If EstaEnArea(srcX, srcY) Then
             Dim p As Position
             p.x = srcX
             p.y = srcY
-            Call ao20audio.PlayWav(CStr(wave), False, ao20audio.ComputeCharFxVolume(p), ao20audio.ComputeCharFxPan(p))
+            Call ao20audio.PlayWav(filename, False, ao20audio.ComputeCharFxVolume(p), ao20audio.ComputeCharFxPan(p))
         End If
     End If
     Exit Sub

--- a/CODIGO/clsAudioEngine.cls
+++ b/CODIGO/clsAudioEngine.cls
@@ -224,7 +224,8 @@ Error_Handl:
     frmDebug.add_text_tracebox "error al cargar musica"
 End Function
 
-Private Function CreateWavBufferFromFile(ByVal file_name As Integer, ByRef new_buffer As DirectSoundSecondaryBuffer8, Optional ByVal Extraido As Boolean = False) As Boolean
+Private Function CreateWavBufferFromFile(ByVal file_name As Integer, ByRef new_buffer As DirectSoundSecondaryBuffer8, Optional ByVal Extraido As Boolean = False, Optional ByVal currentLanguage As e_language = e_language.Spanish) As Boolean
+
 On Error GoTo CreateWavBufferFromFile_Err
     CreateWavBufferFromFile = False
     Debug.Assert Not mDirectSound Is Nothing

--- a/CODIGO/clsAudioEngine.cls
+++ b/CODIGO/clsAudioEngine.cls
@@ -228,6 +228,7 @@ Private Function CreateWavBufferFromFile(ByVal file_name As Integer, ByRef new_b
 On Error GoTo CreateWavBufferFromFile_Err
     CreateWavBufferFromFile = False
     Debug.Assert Not mDirectSound Is Nothing
+    
     Dim dsbd As DSBUFFERDESC
     dsbd.lFlags = DSBCAPS_CTRLFREQUENCY Or DSBCAPS_CTRLPAN Or DSBCAPS_CTRLVOLUME
     dsbd.fxFormat.nFormatTag = WAVE_FORMAT_PCM
@@ -236,38 +237,71 @@ On Error GoTo CreateWavBufferFromFile_Err
     dsbd.fxFormat.nBitsPerSample = 16
     dsbd.fxFormat.nBlockAlign = dsbd.fxFormat.nBitsPerSample / 8 * dsbd.fxFormat.nChannels
     dsbd.fxFormat.lAvgBytesPerSec = dsbd.fxFormat.lSamplesPerSec * dsbd.fxFormat.nBlockAlign
-    Dim filename_with_extension As String: filename_with_extension = file_name & ".wav"
-    #If Compresion Then
-        If Extraido = False Then
-            If Extract_File(wav, GetCompressedResourcesPath(), file_name & ".wav", Windows_Temp_Dir, ResourcesPassword, False) Then
-                Set new_buffer = mDirectSound.CreateSoundBufferFromFile(Windows_Temp_Dir & file_name & ".wav", dsbd)
-                Delete_File Windows_Temp_Dir & filename_with_extension
-                CreateWavBufferFromFile = True
-            End If
-        Else
-            Set new_buffer = mDirectSound.CreateSoundBufferFromFile(Windows_Temp_Dir & file_name & ".wav", dsbd)
-            Delete_File Windows_Temp_Dir & filename_with_extension
-            CreateWavBufferFromFile = True
 
+    Dim langPrefix As String
+    langPrefix = GetLanguagePrefix(currentLanguage)
+
+    Dim prefixed_filename As String
+    Dim unprefixed_filename As String
+    prefixed_filename = langPrefix & "_" & file_name & ".wav"
+    unprefixed_filename = file_name & ".wav"
+
+#If Compresion Then
+    If Extraido = False Then
+        If Extract_File(wav, GetCompressedResourcesPath(), prefixed_filename, Windows_Temp_Dir, ResourcesPassword, False) Then
+            Set new_buffer = mDirectSound.CreateSoundBufferFromFile(Windows_Temp_Dir & prefixed_filename, dsbd)
+            Debug.Print "Usando WAV: " & PathToFile
+
+            Delete_File Windows_Temp_Dir & prefixed_filename
+            CreateWavBufferFromFile = True
+        ElseIf Extract_File(wav, GetCompressedResourcesPath(), unprefixed_filename, Windows_Temp_Dir, ResourcesPassword, False) Then
+            Set new_buffer = mDirectSound.CreateSoundBufferFromFile(Windows_Temp_Dir & unprefixed_filename, dsbd)
+            Debug.Print "Usando WAV: " & PathToFile
+
+            Delete_File Windows_Temp_Dir & unprefixed_filename
+            CreateWavBufferFromFile = True
         End If
-    #Else
-        Dim PathToFile As String
-        PathToFile = ao20audio.GetWavFilesPath() & filename_with_extension
+    Else
+        ' Ya extraído: verificar prefijo primero
+        If FileExist(Windows_Temp_Dir & prefixed_filename, vbArchive) Then
+            Set new_buffer = mDirectSound.CreateSoundBufferFromFile(Windows_Temp_Dir & prefixed_filename, dsbd)
+            Debug.Print "Usando WAV: " & PathToFile
+
+            Delete_File Windows_Temp_Dir & prefixed_filename
+            CreateWavBufferFromFile = True
+        ElseIf FileExist(Windows_Temp_Dir & unprefixed_filename, vbArchive) Then
+            Set new_buffer = mDirectSound.CreateSoundBufferFromFile(Windows_Temp_Dir & unprefixed_filename, dsbd)
+            Debug.Print "Usando WAV: " & PathToFile
+
+            Delete_File Windows_Temp_Dir & unprefixed_filename
+            CreateWavBufferFromFile = True
+        End If
+    End If
+#Else
+    Dim PathToFile As String
+    PathToFile = ao20audio.GetWavFilesPath() & prefixed_filename
+    If FileExist(PathToFile, vbArchive) Then
+        Set new_buffer = mDirectSound.CreateSoundBufferFromFile(PathToFile, dsbd)
+        Debug.Print "Usando WAV: " & PathToFile
+
+        CreateWavBufferFromFile = True
+    Else
+        PathToFile = ao20audio.GetWavFilesPath() & unprefixed_filename
         If FileExist(PathToFile, vbArchive) Then
             Set new_buffer = mDirectSound.CreateSoundBufferFromFile(PathToFile, dsbd)
+            Debug.Print "Usando WAV: " & PathToFile
+
             CreateWavBufferFromFile = True
         End If
+    End If
+#End If
 
-    #End If
-   
     Exit Function
 
 CreateWavBufferFromFile_Err:
     Call RegistrarError(Err.Number, Err.Description, "clsAudioEngine.CreateWavBufferFromFile " & file_name, Erl)
     Resume Next
-    
 End Function
-
 
 Private Function StartPlaying(ByRef Buffer As DirectSoundSecondaryBuffer8, ByVal flags As CONST_DSBPLAYFLAGS, ByVal volume As Long, ByVal pan As Long) As Long
 
@@ -390,7 +424,7 @@ On Error GoTo PlayWav_Error_Handl
 
     If mBuffer(sound_id) Is Nothing Then
         Dim i As Integer
-        Call CreateWavBufferFromFile(sound_id, mBuffer(sound_id))
+        Call CreateWavBufferFromFile(sound_id, mBuffer(sound_id), False, language)
         Debug.Assert Not mBuffer(sound_id) Is Nothing
         If mBuffer(sound_id) Is Nothing Then
             PlayWav = -1

--- a/CODIGO/clsAudioEngine.cls
+++ b/CODIGO/clsAudioEngine.cls
@@ -257,7 +257,7 @@ On Error GoTo CreateWavBufferFromFile_Err
             CreateWavBufferFromFile = True
         ElseIf Extract_File(wav, GetCompressedResourcesPath(), unprefixed_filename, Windows_Temp_Dir, ResourcesPassword, False) Then
             Set new_buffer = mDirectSound.CreateSoundBufferFromFile(Windows_Temp_Dir & unprefixed_filename, dsbd)
-            Debug.Print "Usando WAV: " & PathToFile
+            
 
             Delete_File Windows_Temp_Dir & unprefixed_filename
             CreateWavBufferFromFile = True
@@ -266,13 +266,13 @@ On Error GoTo CreateWavBufferFromFile_Err
         ' Ya extraído: verificar prefijo primero
         If FileExist(Windows_Temp_Dir & prefixed_filename, vbArchive) Then
             Set new_buffer = mDirectSound.CreateSoundBufferFromFile(Windows_Temp_Dir & prefixed_filename, dsbd)
-            Debug.Print "Usando WAV: " & PathToFile
+            
 
             Delete_File Windows_Temp_Dir & prefixed_filename
             CreateWavBufferFromFile = True
         ElseIf FileExist(Windows_Temp_Dir & unprefixed_filename, vbArchive) Then
             Set new_buffer = mDirectSound.CreateSoundBufferFromFile(Windows_Temp_Dir & unprefixed_filename, dsbd)
-            Debug.Print "Usando WAV: " & PathToFile
+            
 
             Delete_File Windows_Temp_Dir & unprefixed_filename
             CreateWavBufferFromFile = True
@@ -283,14 +283,14 @@ On Error GoTo CreateWavBufferFromFile_Err
     PathToFile = ao20audio.GetWavFilesPath() & prefixed_filename
     If FileExist(PathToFile, vbArchive) Then
         Set new_buffer = mDirectSound.CreateSoundBufferFromFile(PathToFile, dsbd)
-        Debug.Print "Usando WAV: " & PathToFile
+        
 
         CreateWavBufferFromFile = True
     Else
         PathToFile = ao20audio.GetWavFilesPath() & unprefixed_filename
         If FileExist(PathToFile, vbArchive) Then
             Set new_buffer = mDirectSound.CreateSoundBufferFromFile(PathToFile, dsbd)
-            Debug.Print "Usando WAV: " & PathToFile
+            
 
             CreateWavBufferFromFile = True
         End If


### PR DESCRIPTION
Se agregó soporte para archivos de audio .wav localizados por idioma.
Ahora, cuando se reproduce un sonido (PlayWav), el sistema intentará cargar un archivo con prefijo de idioma (por ejemplo, en_700.wav, pt_700.wav, etc.).
Si ese archivo no existe, se usará el .wav genérico (700.wav) como respaldo.

Además, se agregó Debug.Print para mostrar en tiempo de ejecución qué archivo se está utilizando, tanto para versiones comprimidas como no comprimidas del cliente.