### PR TITLE
Update TileEngine.bas

### DIFF
--- a/CODIGO/TileEngine.bas
+++ b/CODIGO/TileEngine.bas
@@ -269,7 +269,7 @@ Public Type Char
     BarTime As Single
     MaxBarTime As Integer
     BarAccion As Byte
-    Particula As Byte
+    Particula As Integer
     
     ParticulaTime As Long
     


### PR DESCRIPTION
Pasamos a Integer la propiedad Partícula para poder visualizar correctamente los números mayores a 255