### PR TITLE
Atajos de teclado para sonido y musica

### DIFF
--- a/CODIGO/frmCustomKeys.frm
+++ b/CODIGO/frmCustomKeys.frm
@@ -27,6 +27,28 @@ Begin VB.Form frmCustomKeys
       BackColor       =   &H00FFFFFF&
       ForeColor       =   &H00000000&
       Height          =   300
+      Index           =   39
+      Left            =   4155
+      Locked          =   -1  'True
+      TabIndex        =   95
+      Top             =   6840
+      Width           =   1770
+   End
+   Begin VB.TextBox txConfig 
+      BackColor       =   &H00FFFFFF&
+      ForeColor       =   &H00000000&
+      Height          =   300
+      Index           =   38
+      Left            =   4155
+      Locked          =   -1  'True
+      TabIndex        =   93
+      Top             =   6240
+      Width           =   1770
+   End
+   Begin VB.TextBox txConfig 
+      BackColor       =   &H00FFFFFF&
+      ForeColor       =   &H00000000&
+      Height          =   300
       Index           =   37
       Left            =   2175
       Locked          =   -1  'True
@@ -235,7 +257,7 @@ Begin VB.Form frmCustomKeys
       Height          =   255
       Left            =   4110
       TabIndex        =   52
-      Top             =   5280
+      Top             =   5040
       Width           =   1215
    End
    Begin VB.OptionButton Option1 
@@ -243,7 +265,7 @@ Begin VB.Form frmCustomKeys
       Height          =   255
       Left            =   4110
       TabIndex        =   51
-      Top             =   4920
+      Top             =   4680
       Width           =   1215
    End
    Begin VB.ComboBox AccionList3 
@@ -253,7 +275,7 @@ Begin VB.Form frmCustomKeys
       List            =   "frmCustomKeys.frx":0010
       Style           =   2  'Dropdown List
       TabIndex        =   48
-      Top             =   4080
+      Top             =   3840
       Width           =   1935
    End
    Begin VB.ComboBox AccionList1 
@@ -263,7 +285,7 @@ Begin VB.Form frmCustomKeys
       List            =   "frmCustomKeys.frx":006E
       Style           =   2  'Dropdown List
       TabIndex        =   45
-      Top             =   2880
+      Top             =   2640
       Width           =   1935
    End
    Begin VB.ComboBox AccionList2 
@@ -273,7 +295,7 @@ Begin VB.Form frmCustomKeys
       List            =   "frmCustomKeys.frx":00CC
       Style           =   2  'Dropdown List
       TabIndex        =   44
-      Top             =   3480
+      Top             =   3240
       Width           =   1935
    End
    Begin VB.CommandButton cmdAccion 
@@ -282,7 +304,7 @@ Begin VB.Form frmCustomKeys
       Index           =   0
       Left            =   4080
       TabIndex        =   43
-      Top             =   5640
+      Top             =   5400
       Width           =   1695
    End
    Begin VB.TextBox txConfig 
@@ -591,6 +613,30 @@ Begin VB.Form frmCustomKeys
    Begin VB.Label lblSalirDel 
       AutoSize        =   -1  'True
       BackStyle       =   0  'Transparent
+      Caption         =   "Activar/Desactivar musica"
+      ForeColor       =   &H00000000&
+      Height          =   195
+      Index           =   28
+      Left            =   4155
+      TabIndex        =   96
+      Top             =   6600
+      Width           =   1860
+   End
+   Begin VB.Label lblSalirDel 
+      AutoSize        =   -1  'True
+      BackStyle       =   0  'Transparent
+      Caption         =   "Activar/Desactivar sonido"
+      ForeColor       =   &H00000000&
+      Height          =   195
+      Index           =   27
+      Left            =   4155
+      TabIndex        =   94
+      Top             =   6000
+      Width           =   1845
+   End
+   Begin VB.Label lblSalirDel 
+      AutoSize        =   -1  'True
+      BackStyle       =   0  'Transparent
       Caption         =   "Menu de grupo"
       ForeColor       =   &H00000000&
       Height          =   195
@@ -858,7 +904,7 @@ Begin VB.Form frmCustomKeys
       Index           =   32
       Left            =   4110
       TabIndex        =   50
-      Top             =   4560
+      Top             =   4320
       Width           =   1785
    End
    Begin VB.Label lblSalirDel 
@@ -878,7 +924,7 @@ Begin VB.Form frmCustomKeys
       Index           =   31
       Left            =   4080
       TabIndex        =   49
-      Top             =   3840
+      Top             =   3600
       Width           =   1140
    End
    Begin VB.Label lblSalirDel 
@@ -898,7 +944,7 @@ Begin VB.Form frmCustomKeys
       Index           =   33
       Left            =   4080
       TabIndex        =   47
-      Top             =   2640
+      Top             =   2400
       Width           =   1140
    End
    Begin VB.Label lblSalirDel 
@@ -918,7 +964,7 @@ Begin VB.Form frmCustomKeys
       Index           =   34
       Left            =   4080
       TabIndex        =   46
-      Top             =   3240
+      Top             =   3000
       Width           =   1140
    End
    Begin VB.Label lblSalirDel 

--- a/CODIGO/frmOpciones.frm
+++ b/CODIGO/frmOpciones.frm
@@ -944,11 +944,11 @@ Private Sub chkO_MouseUp(Index As Integer, Button As Integer, Shift As Integer, 
 
         Case 0
 
-            Call toggleMusic
+            Call ToggleMusic
 
         Case 1
         
-            Call toggleSoundEffects
+            Call ToggleSoundEffects
             
         Case 2
 
@@ -1607,7 +1607,7 @@ scrVolume_Change_Err:
     Resume Next
 End Sub
 
-Public Sub toggleSoundEffects()
+Public Sub ToggleSoundEffects()
 
 On Error GoTo toggleSoundEffects_Err
 
@@ -1631,11 +1631,11 @@ On Error GoTo toggleSoundEffects_Err
     Exit Sub
     
 toggleSoundEffects_Err:
-    Call RegistrarError(Err.Number, Err.Description, "frmOpciones.toggleSoundEffects", Erl)
+    Call RegistrarError(Err.Number, Err.Description, "frmOpciones.ToggleSoundEffects", Erl)
     Resume Next
 End Sub
 
-Public Sub toggleMusic()
+Public Sub ToggleMusic()
 
 On Error GoTo toggleMusic_Err
 
@@ -1657,7 +1657,7 @@ On Error GoTo toggleMusic_Err
     Exit Sub
     
 toggleMusic_Err:
-    Call RegistrarError(Err.Number, Err.Description, "frmOpciones.toggleMusic", Erl)
+    Call RegistrarError(Err.Number, Err.Description, "frmOpciones.ToggleMusic", Erl)
     Resume Next
 End Sub
 

--- a/CODIGO/frmOpciones.frm
+++ b/CODIGO/frmOpciones.frm
@@ -802,8 +802,6 @@ Private Sub cbRenderNpcs_Click()
         Call SaveSetting("OPCIONES", "NpcsEnRender", cbRenderNpcs.ListIndex)
     End If
 End Sub
-
-
 Private Sub Check4_MouseUp(Button As Integer, Shift As Integer, x As Single, y As Single)
     
     On Error GoTo Check4_MouseUp_Err
@@ -946,44 +944,12 @@ Private Sub chkO_MouseUp(Index As Integer, Button As Integer, Shift As Integer, 
 
         Case 0
 
-            If ao20audio.MusicEnabled Then
-                ao20audio.StopAllPlayback
-                ao20audio.MusicEnabled = False
-                scrMidi.enabled = False
-            Else
-                ao20audio.MusicEnabled = True
-                scrMidi.enabled = True
-            End If
-
-            If Not ao20audio.MusicEnabled Then
-                chko(0).Picture = Nothing
-            Else
-                chko(0).Picture = LoadInterface("check-amarillo.bmp")
-
-            End If
+            Call toggleMusic
 
         Case 1
-
-            If ao20audio.FxEnabled Then
-                ao20audio.FxEnabled = 0
-                chko(2).enabled = False
-                scrVolume.enabled = False
-            
-                Call ao20audio.StopAllPlayback
-            Else
-                ao20audio.FxEnabled = 1
-                chko(2).enabled = True
-                scrVolume.enabled = True
-
-            End If
         
-            If ao20audio.FxEnabled = 0 Then
-                chko(1).Picture = Nothing
-            Else
-                chko(1).Picture = LoadInterface("check-amarillo.bmp")
-
-            End If
-
+            Call toggleSoundEffects
+            
         Case 2
 
             If FxNavega = 1 Then
@@ -1563,8 +1529,6 @@ HScroll1_Change_Err:
     
 End Sub
 
-
-
 Private Sub instagram_Click()
     
     On Error GoTo instagram_Click_Err
@@ -1578,15 +1542,6 @@ instagram_Click_Err:
     Call RegistrarError(Err.Number, Err.Description, "frmOpciones.instagram_Click", Erl)
     Resume Next
     
-End Sub
-
-
-Private Sub Label3_Click()
-
-End Sub
-
-Private Sub lblIdioma_Click()
-
 End Sub
 
 Private Sub num_comp_inv_Click()
@@ -1651,3 +1606,58 @@ scrVolume_Change_Err:
     Call RegistrarError(Err.Number, Err.Description, "frmOpciones.scrVolume_Change", Erl)
     Resume Next
 End Sub
+
+Public Sub toggleSoundEffects()
+
+On Error GoTo toggleSoundEffects_Err
+
+    If ao20audio.FxEnabled Then
+        ao20audio.FxEnabled = 0
+        chko(2).enabled = False
+        scrVolume.enabled = False
+        Call ao20audio.StopAllPlayback
+    Else
+        ao20audio.FxEnabled = 1
+        chko(2).enabled = True
+        scrVolume.enabled = True
+    End If
+    
+    If ao20audio.FxEnabled = 0 Then
+        chko(1).Picture = Nothing
+    Else
+        chko(1).Picture = LoadInterface("check-amarillo.bmp")
+    
+    End If
+    Exit Sub
+    
+toggleSoundEffects_Err:
+    Call RegistrarError(Err.Number, Err.Description, "frmOpciones.toggleSoundEffects", Erl)
+    Resume Next
+End Sub
+
+Public Sub toggleMusic()
+
+On Error GoTo toggleMusic_Err
+
+    If ao20audio.MusicEnabled Then
+        ao20audio.StopAllPlayback
+        ao20audio.MusicEnabled = False
+        scrMidi.enabled = False
+    Else
+        ao20audio.MusicEnabled = True
+        scrMidi.enabled = True
+    End If
+    
+    If Not ao20audio.MusicEnabled Then
+        chko(0).Picture = Nothing
+    Else
+        chko(0).Picture = LoadInterface("check-amarillo.bmp")
+    
+    End If
+    Exit Sub
+    
+toggleMusic_Err:
+    Call RegistrarError(Err.Number, Err.Description, "frmOpciones.toggleMusic", Erl)
+    Resume Next
+End Sub
+

--- a/CODIGO/modBindKeys.bas
+++ b/CODIGO/modBindKeys.bas
@@ -452,9 +452,9 @@ Public Function Accionar(ByVal KeyCode As Integer) As Boolean
                 Call WriteRequestGrupo
             End If
         Case BindKeys(eToggleSound).KeyCode
-            Call frmOpciones.toggleSoundEffects
+            Call frmOpciones.ToggleSoundEffects
         Case BindKeys(eToggleMusic).KeyCode
-            Call frmOpciones.toggleMusic
+            Call frmOpciones.ToggleMusic
         Case Else
             Accionar = False
             Exit Function

--- a/CODIGO/modBindKeys.bas
+++ b/CODIGO/modBindKeys.bas
@@ -88,6 +88,8 @@ Public Enum e_KeyAction
     eSegResu = 36
     eQuestList = 37
     eGroupList = 38
+    eToggleSound = 39
+    eToggleMusic = 40
     
     [eMaxBinds]
 End Enum
@@ -449,6 +451,10 @@ Public Function Accionar(ByVal KeyCode As Integer) As Boolean
             If FrmGrupo.visible = False Then
                 Call WriteRequestGrupo
             End If
+        Case BindKeys(eToggleSound).KeyCode
+            Call frmOpciones.toggleSoundEffects
+        Case BindKeys(eToggleMusic).KeyCode
+            Call frmOpciones.toggleMusic
         Case Else
             Accionar = False
             Exit Function


### PR DESCRIPTION
Este cambio agrega la posibilidad de configurar atajos de teclado para las siguientes acciones del juego:

-Activar/desactivar sonidos
-Activar/desactivar música

Estas acciones ahora pueden ser bindeadas por los usuarios desde Ajustes > Configurar teclas.