### PR TITLE
Add Legionary Faction insurance messages to languages

### DIFF
--- a/Languages/1.json
+++ b/Languages/1.json
@@ -649,6 +649,8 @@
 	"MENSAJE_QUEST_NIVEL_REQUERIDO": "Nivel requerido: ",
 	"MENSAJE_QUEST_NIVEL_MAXIMO": "Nivel máximo: ",
 	"MENSAJE_QUEST_REQUERIDA": "Quest: ",
-	"MENSAJE_QUEST_CLASE": "Clase: "
+	"MENSAJE_QUEST_CLASE": "Clase: ",
+	"MENSAJE_SEG_LEGION_ACTIVADO":"Has activado el seguro de Facción Legionaria.",
+	"MENSAJE_SEG_LEGION_DESACTIVADO":"Has desactivado el seguro de Facción Legionaria, ahora puedes atacar a un Legión."
 
 }

--- a/Languages/2.json
+++ b/Languages/2.json
@@ -649,6 +649,8 @@
 	"MENSAJE_QUEST_NIVEL_REQUERIDO": "Required level: ",
 	"MENSAJE_QUEST_NIVEL_MAXIMO": "Maximum level: ",
 	"MENSAJE_QUEST_REQUERIDA": "Quest: ",
-	"MENSAJE_QUEST_CLASE": "Class: "
+	"MENSAJE_QUEST_CLASE": "Class: ",
+	"MENSAJE_SEG_LEGION_ACTIVADO":"You have activated the Legionary Faction insurance.",
+	"MENSAJE_SEG_LEGION_DESACTIVADO":"You have disabled the Legionary Faction insurance, you can now attack a Legion."
 
 }

--- a/Languages/3.json
+++ b/Languages/3.json
@@ -649,6 +649,8 @@
   "MENSAJE_QUEST_NIVEL_REQUERIDO": "Nível requerido: ",
   "MENSAJE_QUEST_NIVEL_MAXIMO": "Nível máximo: ",
   "MENSAJE_QUEST_REQUERIDA": "Missão: ",
-  "MENSAJE_QUEST_CLASE": "Aula: "
-
+  "MENSAJE_QUEST_CLASE": "Aula: ",
+  "MENSAJE_SEG_LEGION_ACTIVADO":"Você ativou o seguro da Facção Legionária.",
+  "MENSAJE_SEG_LEGION_DESACTIVADO":"Você desativou o seguro da Facção Legionária e agora pode atacar uma Legião."
+	
 }

--- a/Languages/4.json
+++ b/Languages/4.json
@@ -649,6 +649,8 @@
   "MENSAJE_QUEST_NIVEL_REQUERIDO": "Niveau requis: ",
   "MENSAJE_QUEST_NIVEL_MAXIMO": "Niveau maximum: ",
   "MENSAJE_QUEST_REQUERIDA": "Mission: ",
-  "MENSAJE_QUEST_CLASE": "Classe: "
+  "MENSAJE_QUEST_CLASE": "Classe: ",
+  "MENSAJE_SEG_LEGION_ACTIVADO":"Vous avez activé l'assurance de la faction légionnaire.",
+  "MENSAJE_SEG_LEGION_DESACTIVADO":"Vous avez désactivé l'assurance de la faction légionnaire, vous pouvez désormais attaquer une Légion."
 
 }

--- a/Languages/5.json
+++ b/Languages/5.json
@@ -649,6 +649,8 @@
   "MENSAJE_QUEST_NIVEL_REQUERIDO": "Livello richiesto: ",
   "MENSAJE_QUEST_NIVEL_MAXIMO": "Livello massimo: ",
   "MENSAJE_QUEST_REQUERIDA": "Missione: ",
-  "MENSAJE_QUEST_CLASE": "Classe: "
+  "MENSAJE_QUEST_CLASE": "Classe: ",
+  "MENSAJE_SEG_LEGION_ACTIVADO":"Hai attivato l'assicurazione della Fazione Legionaria.",
+  "MENSAJE_SEG_LEGION_DESACTIVADO":"Hai disattivato l'assicurazione della fazione dei Legionari, ora puoi attaccare una Legione."
 
 }


### PR DESCRIPTION
Introduced new messages for activating and deactivating Legionary Faction insurance in Spanish, English, Portuguese, French, and Italian language files to support related game features.