### PR TITLE
Add TexHighWaterMark‐based eviction threshold

### DIFF
--- a/CODIGO/Declares.bas
+++ b/CODIGO/Declares.bas
@@ -298,6 +298,7 @@ Public ChatCombate                 As Byte
 Public ChatGlobal                  As Byte
 Public PantallaCompleta            As Boolean
 Public NumTexRelease               As Integer
+Public TexHighWaterMark            As Long
 Public DisableDungeonLighting      As Boolean
 Public MostrarIconosMeteorologicos As Byte
 Public OpcionMenu                  As Byte

--- a/CODIGO/TileEngine_Map.bas
+++ b/CODIGO/TileEngine_Map.bas
@@ -22,10 +22,23 @@ Sub SwitchMap(ByVal map As Integer, Optional ByVal NewResourceMap As Integer = 0
 
     
     On Error GoTo SwitchMap_Err
+
     
+    ' During map transition, free up a batch of old textures if we’re over our MB threshold
     If Not SurfaceDB Is Nothing Then
-    
-     SurfaceDB.ReleaseUnusedTextures NumTexRelease
+        ' GetAllocatedBytes returns total usage in bytes, so convert to MB
+        Dim usedBytes As Double
+        Dim usedMB    As Double
+        usedBytes = SurfaceDB.GetAllocatedBytes()
+        usedMB = usedBytes / 1048576#
+        If usedMB >= TexHighWaterMark Then
+            ' Optional debug log
+            Debug.Print "Texture memory " & _
+                        format$(usedMB, "0.00") & " MB = " & _
+                        TexHighWaterMark & " MB ? releasing " & NumTexRelease & " textures"
+            ' Evict the configured number of unused textures
+            SurfaceDB.ReleaseUnusedTextures NumTexRelease
+        End If
     End If
     
     If NewResourceMap < 1 Then

--- a/CODIGO/ao20config.bas
+++ b/CODIGO/ao20config.bas
@@ -106,7 +106,50 @@ Sub LoadConfig()
     InfoItemsEnRender = Val(GetSetting("VIDEO", "InfoItemsEnRender"))
     ModoAceleracion = GetSetting("VIDEO", "Aceleracion")
     DisableDungeonLighting = Val(GetSetting("VIDEO", "DisableDungeonLighting"))
+    '------------------------------------------------------------------------------
+    ' Configuration: VIDEO.NumTexRelease
+    '
+    ' When the user transitions from one map to the next, the texture manager will
+    ' eagerly free up a batch of textures to keep memory under control.
+    '
+    ' Effective value (clamped 25…250):
+    '   NumTexRelease = max(25, min(GetSetting("VIDEO", "NumTexRelease"), 250))
+    '
+    '   • Reads the INI setting [VIDEO] NumTexRelease
+    '   • Ensures at least 25 textures are freed per transition
+    '   • Caps the release at 250 textures to avoid excessive unloading
+    '
+    ' Tuning:
+    '   – Higher values free more textures (reducing VRAM use more aggressively)
+    '     but may incur extra reload costs.
+    '   – Lower values free fewer textures (less reload overhead)
+    '     but risk higher memory usage.
+    '------------------------------------------------------------------------------
     NumTexRelease = max(25, min(GetSetting("VIDEO", "NumTexRelease"), 250))
+
+
+    '------------------------------------------------------------------------------
+    ' Configuration: VIDEO.TexHighWaterMark
+    '
+    ' Before performing bulk-free on map transition, the manager checks that the
+    ' current total texture usage (in MB) is at or above this threshold. If usage
+    ' is below, no eager release occurs.
+    '
+    ' Effective value (clamped 200…600 MB):
+    '   TexHighWaterMark = max(200, min(GetSetting("VIDEO", "TexHighWaterMark"), 600))
+    '
+    '   • Reads the INI setting [VIDEO] TexHighWaterMark (in megabytes)
+    '   • Ensures the high-water mark is at least 200 MB
+    '   • Caps the high-water mark at 600 MB to avoid overly late eviction
+    '
+    ' Tuning:
+    '   – A lower threshold triggers eviction more often, keeping VRAM tighter
+    '     at the cost of potential stutter.
+    '   – A higher threshold delays eviction, reducing stutter but increasing
+    '     peak memory usage.
+    '------------------------------------------------------------------------------
+    TexHighWaterMark = max(200, min(GetSetting("VIDEO", "TexHighWaterMark"), 600))
+
     
     Dim Value As String
     Value = GetSetting("VIDEO", "MostrarRespiracion")


### PR DESCRIPTION
* Inject logic in the map‐transition path to convert `SurfaceDB.GetAllocatedBytes()` (bytes) into megabytes (`usedMB`) by dividing by 1,048,576.
* Compare `usedMB` against the existing `TexHighWaterMark` (already in MB) before calling `SurfaceDB.ReleaseUnusedTextures NumTexRelease`.
* Added `usedBytes` and `usedMB` locals to hold the raw and converted values, respectively.
* Emit a debug print that shows the converted MB usage, the threshold, and how many textures will be released.
* Ensures eviction only occurs when texture memory in MB exceeds the configured high‐water mark.