### PR TITLE
Mostrar correctamente el porcentaje en la resistencia mágica

### DIFF
--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -1633,7 +1633,7 @@ Private Sub HandleUpdateRM()
     Dim Value As Integer
 
     Value = Reader.ReadInt16
-    frmMain.lblResis = "+" & Value
+    frmMain.lblResis = "+" & value & "%"
 
     Exit Sub
 


### PR DESCRIPTION
Agrego el signo "%" a la resistencia mágica para que se muestre correctamente.