### PR TITLE
Fix mensaje seguro de clan activado

### DIFF
--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -1526,7 +1526,7 @@ Private Sub HandleClanSeguro()
         SeguroClanX = False
         
     Else
-        Call AddtoRichTextBox(frmMain.RecTxt, JsonLanguage.Item("MENSAJE_SEGURO_CLAN_ACTIVADO."), 65, 190, 156, False, False, False)
+        Call AddtoRichTextBox(frmMain.RecTxt, JsonLanguage.Item("MENSAJE_SEGURO_CLAN_ACTIVADO"), 65, 190, 156, False, False, False)
         frmMain.ImgSegClan = LoadInterface("boton-seguro-clan-on.bmp")
         SeguroClanX = True
 


### PR DESCRIPTION
Saco el punto (.) para que el mensaje MENSAJE_SEGURO_CLAN_ACTIVADO se muestre correctamente en consola.