### PR TITLE
New /SumAll

### DIFF
--- a/CODIGO/ProtocolCmdParse.bas
+++ b/CODIGO/ProtocolCmdParse.bas
@@ -1224,7 +1224,17 @@ Public Sub ParseUserCommand(ByVal RawCommand As String)
                     Call ShowConsoleMsg(JsonLanguage.Item("MENSAJE_FALTAN_PARAMETROS_UTILICE"))
                     ' End If
                 End If
-                
+            Case "/SUMALL"
+
+                If EsGM Then
+                    'If notNullArguments Then
+                    Call WriteSummonChar(ArgumentosRaw)
+
+                    'Else
+                    'Avisar que falta el parametro
+                    Call ShowConsoleMsg(JsonLanguage.Item("MENSAJE_FALTAN_PARAMETROS_UTILICE"))
+                    ' End If
+                End If    
             Case "/CC"
                 If EsGM Then
                     Call WriteSpawnListRequest

--- a/CODIGO/Protocol_Writes.bas
+++ b/CODIGO/Protocol_Writes.bas
@@ -4086,6 +4086,23 @@ WriteSummonChar_Err:
         '</EhFooter>
 End Sub
 
+Public Sub WriteSummonCharMulti(ByVal userNames As String)
+    Dim arrUsers() As String
+    Dim i As Integer
+    Dim maxUsers As Integer
+    
+    arrUsers = Split(userNames, ",")
+    maxUsers = 4
+        
+    If UBound(arrUsers) > maxUsers - 1 Then
+        ReDim Preserve arrUsers(maxUsers - 1)
+    End If
+    
+    For i = LBound(arrUsers) To UBound(arrUsers)
+        Call WriteSummonChar(Trim$(arrUsers(i)))
+    Next i
+End Sub
+
 ''
 ' Writes the "SpawnListRequest" message to the outgoing data buffer.
 '


### PR DESCRIPTION
To help administrators who organize tournaments, in situations where it is necessary to summon more than one person, this allows you to summon a duo, trio, or quartet.