### PR TITLE
Adjust frame calculation with 0.5 multiplier

### DIFF
--- a/CODIGO/TileEngine_Map.bas
+++ b/CODIGO/TileEngine_Map.bas
@@ -308,7 +308,7 @@ Public Sub Draw_Sombra(ByRef grh As grh, ByVal x As Integer, ByVal y As Integer,
             num = GrhData(Grh.GrhIndex).NumFrames
             If num > 1 Then
                 ' Unificado (SIN 0.5)
-                elapsed = Fix((FrameTime - Grh.started) / Grh.speed)
+                Elapsed = Fix(0.5 * (FrameTime - Grh.started) / Grh.speed)
 
                 If Grh.Loops = INFINITE_LOOPS Or elapsed < num * (Grh.Loops + 1) Then
                     CurrentFrame = (elapsed Mod num) + 1

--- a/CODIGO/engine.bas
+++ b/CODIGO/engine.bas
@@ -575,7 +575,7 @@ Public Sub Draw_Grh(ByRef grh As grh, ByVal x As Integer, ByVal y As Integer, By
             num = GrhData(Grh.GrhIndex).NumFrames
             If num > 1 Then
                 ' Unificado: SIN 0.5
-                elapsed = Fix((FrameTime - Grh.started) / Grh.speed)
+                Elapsed = Fix(0.5 * (FrameTime - Grh.started) / Grh.speed)
 
                 If Grh.Loops = INFINITE_LOOPS Or elapsed < num * (Grh.Loops + 1) Then
                     CurrentFrame = (elapsed Mod num) + 1
@@ -664,7 +664,7 @@ Public Sub Draw_Grh_Breathing(ByRef grh As grh, ByVal x As Integer, ByVal y As I
             num = GrhData(Grh.GrhIndex).NumFrames
             If num > 1 Then
                 ' Unificado: SIN 0.5
-                elapsed = Fix((FrameTime - Grh.started) / Grh.speed)
+                Elapsed = Fix(0.5 * (FrameTime - Grh.started) / Grh.speed)
 
                 If Grh.Loops = INFINITE_LOOPS Or elapsed < num * (Grh.Loops + 1) Then
                     CurrentFrame = (elapsed Mod num) + 1
@@ -863,7 +863,7 @@ Private Sub Draw_GrhSinLuz(ByRef grh As grh, ByVal x As Integer, ByVal y As Inte
             num = GrhData(Grh.GrhIndex).NumFrames
             If num > 1 Then
                 ' Unificado: SIN 0.5
-                elapsed = Fix((FrameTime - Grh.started) / Grh.speed)
+                Elapsed = Fix(0.5 * (FrameTime - Grh.started) / Grh.speed)
 
                 If Grh.Loops = INFINITE_LOOPS Or elapsed < num * (Grh.Loops + 1) Then
                     CurrentFrame = (elapsed Mod num) + 1
@@ -3000,7 +3000,7 @@ Public Sub Grh_Render_Advance(ByRef grh As grh, ByVal screen_x As Integer, ByVal
         num = GrhData(Grh.GrhIndex).NumFrames
         If num > 1 Then
             ' Unificado: SIN 0.5
-            elapsed = Fix((FrameTime - Grh.started) / Grh.speed)
+            Elapsed = Fix(0.5 * (FrameTime - Grh.started) / Grh.speed)
 
             If Grh.Loops = INFINITE_LOOPS Or elapsed < num * (Grh.Loops + 1) Then
                 CurrentFrame = (elapsed Mod num) + 1
@@ -3058,7 +3058,7 @@ Public Sub Grh_Render(ByRef grh As grh, ByVal screen_x As Integer, ByVal screen_
         num = GrhData(Grh.GrhIndex).NumFrames
         If num > 1 Then
             ' Unificado: SIN 0.5
-            elapsed = Fix((FrameTime - Grh.started) / Grh.speed)
+            Elapsed = Fix(0.5 * (FrameTime - Grh.started) / Grh.speed)
 
             If Grh.Loops = INFINITE_LOOPS Or elapsed < num * (Grh.Loops + 1) Then
                 CurrentFrame = (elapsed Mod num) + 1
@@ -4375,7 +4375,7 @@ Public Sub Draw_Grh_ItemInWater(ByRef grh As grh, ByVal x As Integer, ByVal y As
             num = GrhData(Grh.GrhIndex).NumFrames
             If num > 1 Then
                 ' Unificado: SIN 0.5
-                elapsed = Fix((FrameTime - Grh.started) / Grh.speed)
+                Elapsed = Fix(0.5 * (FrameTime - Grh.started) / Grh.speed)
 
                 If Grh.Loops = INFINITE_LOOPS Or elapsed < num * (Grh.Loops + 1) Then
                     CurrentFrame = (elapsed Mod num) + 1
@@ -4450,7 +4450,7 @@ Public Sub Draw_Grh_Precalculated(ByRef grh As grh, ByRef rgb_list() As RGBA, By
         num = GrhData(Grh.GrhIndex).NumFrames
         If num > 1 Then
             ' Unificado: SIN 0.5
-            elapsed = Fix((FrameTime - Grh.started) / Grh.speed)
+            Elapsed = Fix(0.5 * (FrameTime - Grh.started) / Grh.speed)
 
             If Grh.Loops = INFINITE_LOOPS Or elapsed < num * (Grh.Loops + 1) Then
                 CurrentFrame = (elapsed Mod num) + 1


### PR DESCRIPTION
Updated frame advancement logic in TileEngine_Map.bas and engine.bas to multiply elapsed time by 0.5 when calculating animation frames. This change affects all relevant drawing and rendering routines to ensure consistent frame progression.