### PR TITLE
Ajusta color de fondo al previsualizar NPCs

### DIFF
--- a/CODIGO/engine.bas
+++ b/CODIGO/engine.bas
@@ -4843,7 +4843,7 @@ Public Sub DibujarNPC(PicBox As PictureBox, ByVal Head As Integer, ByVal Body As
         x = (PicBox.ScaleWidth - GrhData(bodyGrh).pixelWidth) \ 2
         y = min(PicBox.ScaleHeight - GrhData(bodyGrh).pixelHeight + BodyData(Body).HeadOffset.y \ 2, (PicBox.ScaleHeight - GrhData(bodyGrh).pixelHeight) \ 2)
         
-        Call Grh_Render_To_Hdc(PicBox, bodyGrh, x, y, False, RGB(11, 11, 11))
+        Call Grh_Render_To_Hdc(PicBox, bodyGrh, x, y, False, RGB(96, 96, 96))
 
         If headGrh Then
             headGrh = GrhData(headGrh).Frames(1)


### PR DESCRIPTION
## Summary
- ajusta el color de fondo usado al renderizar NPCs en vistas previas para mejorar el contraste de sprites oscuros

## Testing
- no se realizaron pruebas automatizadas (cambio visual)


------
https://chatgpt.com/codex/tasks/task_e_68ceb0f27d748333af9251ad7ac2e98e