### PR TITLE
Align preview NPC preview clear color

### DIFF
--- a/CODIGO/frmMapaGrande.frm
+++ b/CODIGO/frmMapaGrande.frm
@@ -1172,7 +1172,7 @@ Private Sub PreviewNPC_RenderFrame(ByVal forceClear As Boolean)
         y = (pic.ScaleHeight - GrhData(bodyFrameGrh).pixelHeight) \ 2
         
         ' Dibujo cuerpo (limpia el backbuffer del PictureBox)
-        Call Grh_Render_To_Hdc(pic, bodyFrameGrh, x, y, False, RGB(11, 11, 11))
+        Call Grh_Render_To_Hdc(pic, bodyFrameGrh, x, y, False, RGB(96, 96, 96))
         
         ' Superponer cabeza con mismo criterio que DibujarNPC
         If headFrameGrh <> 0 And pvBody <> 0 Then
@@ -1185,7 +1185,7 @@ Private Sub PreviewNPC_RenderFrame(ByVal forceClear As Boolean)
         ' Si no hay cuerpo, mostramos solo la cabeza centrada
         x = (pic.ScaleWidth - GrhData(headFrameGrh).pixelWidth) \ 2
         y = (pic.ScaleHeight - GrhData(headFrameGrh).pixelHeight) \ 2
-        Call Grh_Render_To_Hdc(pic, headFrameGrh, x, y, False, RGB(11, 11, 11))
+        Call Grh_Render_To_Hdc(pic, headFrameGrh, x, y, False, RGB(96, 96, 96))
     Else
         ' Nada que dibujar
         pic.Refresh


### PR DESCRIPTION
## Summary
- align the map preview NPC rendering background color with the lighter tone used by the NPC drawing routine

## Testing
- not run (VB6 UI change)


------
https://chatgpt.com/codex/tasks/task_e_68cecfa11e40833395ba75d5c491c94a