### PR TITLE
WIP Add support for resource depletion graphics

### DIFF
--- a/CODIGO/ModUtils.bas
+++ b/CODIGO/ModUtils.bas
@@ -190,6 +190,7 @@ Public NameMaps(1 To 1000) As NameMapas
 Public Type ObjDatas
 
     GrhIndex As Long ' Indice del grafico que representa el obj
+    GrhIndexOff As Long ' Indice del grafico cuando el recurso esta agotado
     Name As String
     MinDef As Integer
     MaxDef As Integer

--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -3404,6 +3404,7 @@ Private Sub HandleObjectCreate()
     Dim id       As Long
     
     Dim ElementalTags As Long
+    Dim GrhIndexToUse As Long
     x = Reader.ReadInt8()
     y = Reader.ReadInt8()
     
@@ -3412,12 +3413,18 @@ Private Sub HandleObjectCreate()
     Amount = Reader.ReadInt16
     
     ElementalTags = Reader.ReadInt32
-    MapData(x, y).ObjGrh.GrhIndex = ObjData(ObjIndex).GrhIndex
-    
+
+    GrhIndexToUse = ObjData(ObjIndex).GrhIndex
+    If Amount <= 0 And ObjData(ObjIndex).GrhIndexOff <> 0 Then
+        GrhIndexToUse = ObjData(ObjIndex).GrhIndexOff
+    End If
+
+    MapData(x, y).ObjGrh.GrhIndex = GrhIndexToUse
+
     MapData(x, y).OBJInfo.ObjIndex = ObjIndex
-    
+
     MapData(x, y).OBJInfo.Amount = Amount
-    
+
     MapData(x, y).OBJInfo.ElementalTags = ElementalTags
     Call InitGrh(MapData(x, y).ObjGrh, MapData(x, y).ObjGrh.GrhIndex)
     

--- a/CODIGO/Recursos.bas
+++ b/CODIGO/Recursos.bas
@@ -1256,6 +1256,9 @@ Public Sub CargarMapa(ByVal map As Integer)
                 MapData(Objetos(i).x, Objetos(i).y).OBJInfo.ObjIndex = Objetos(i).ObjIndex
                 MapData(Objetos(i).x, Objetos(i).y).OBJInfo.Amount = Objetos(i).ObjAmmount
                 MapData(Objetos(i).x, Objetos(i).y).ObjGrh.GrhIndex = ObjData(Objetos(i).ObjIndex).GrhIndex
+                If MapData(Objetos(i).x, Objetos(i).y).OBJInfo.Amount <= 0 And ObjData(Objetos(i).ObjIndex).GrhIndexOff <> 0 Then
+                    MapData(Objetos(i).x, Objetos(i).y).ObjGrh.GrhIndex = ObjData(Objetos(i).ObjIndex).GrhIndexOff
+                End If
                 Call InitGrh(MapData(Objetos(i).x, Objetos(i).y).ObjGrh, MapData(Objetos(i).x, Objetos(i).y).ObjGrh.GrhIndex)
 
             Next i
@@ -1656,6 +1659,7 @@ Public Sub CargarIndicesOBJ()
     For Obj = 1 To NumOBJs
         DoEvents
         ObjData(Obj).GrhIndex = Val(Leer.GetValue("OBJ" & Obj, "grhindex"))
+        ObjData(Obj).GrhIndexOff = Val(Leer.GetValue("OBJ" & Obj, "GrhIndexOff"))
         If Obj = 403 Then
             frmDebug.add_text_tracebox "asd"
         End If


### PR DESCRIPTION
## Summary
- add `GrhIndexOff` to the object data so depleted resources can reference a different sprite
- load the optional `GrhIndexOff` value from the resource index and use it when map tiles or incoming packets indicate a resource without remaining amount

## Testing
- not run (VB6 client has no automated test suite)


------
https://chatgpt.com/codex/tasks/task_e_68d41d75761c8333abd93555183694ec