### PR TITLE
Corrección del offset de la cabeza en los carteles de NPC

### DIFF
--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -1642,7 +1642,7 @@ Private Sub HandleChatOverHeadImpl(ByVal chat As String, _
                             50, 80, bodyGrh, 1)
                 Else
                     Dim HeadOffsetY As Integer
-                    HeadOffsetY = CInt(BodyData(NpcData(text).Body).HeadOffset.y)
+                    HeadOffsetY = CInt(BodyData(NpcData(text).Body).HeadOffset.y) - 30
                     Call mostrarCartel(Split(NpcData(text).Name, " <")(0), NpcData(text).desc, headGrh, 200 + 30 * Len(chat), &H164B8A, , , True, 100, 479, 100, 535, 20, 500, _
                             50, 100, bodyGrh, HeadOffsetY)
                 End If


### PR DESCRIPTION
Anteriormente, la cabeza se dibujaba desalineada (demasiado abajo), debido a que el HeadOffsetY provenía directamente de BodyData y no estaba calibrado correctamente.

Se aplicó un ajuste manual al offset para que la cabeza quede correctamente posicionada sobre el cuerpo.