### PR TITLE
WIP Add randomized special-fishing parameters and input-pause/resume logic

### DIFF
--- a/CODIGO/General.bas
+++ b/CODIGO/General.bas
@@ -1421,12 +1421,25 @@ Function BeautifyBigNumber(ByVal Number As Long) As String
     End If
 End Function
 
+Public Sub RandomizarParametrosPescaEspecial()
+    CentroZonaAciertoPesca = RandomNumber(88, 114)
+    RadioZonaAciertoPesca = RandomNumber(12, 19)
+    VelocidadFactorBarraPesca = CSng(RandomNumber(85, 126) / 100)
+End Sub
+
 Public Function IntentarObtenerPezEspecial()
     Dim acierto As Byte
+    Dim totalIntentos As Long
+    Dim tickActual As Long
+    Dim limiteInferior As Long
+    Dim limiteSuperior As Long
+    tickActual = GetTickCount()
+    If tickActual < PescaInputPauseUntil Then Exit Function
     frmDebug.add_text_tracebox "Aciertos: " & ContadorIntentosPescaEspecial_Acertados & "Posicion barra : " & PosicionBarra
-    'El + y -10 es por inputLag (Margen de error)
     If PuedeIntentar Then
-        If PosicionBarra >= (90 - 15) And PosicionBarra <= (111 + 15) Then
+        limiteInferior = CentroZonaAciertoPesca - RadioZonaAciertoPesca
+        limiteSuperior = CentroZonaAciertoPesca + RadioZonaAciertoPesca
+        If PosicionBarra >= limiteInferior And PosicionBarra <= limiteSuperior Then
             ContadorIntentosPescaEspecial_Acertados = ContadorIntentosPescaEspecial_Acertados + 1
             acierto = 1
         Else
@@ -1434,21 +1447,19 @@ Public Function IntentarObtenerPezEspecial()
             acierto = 2
         End If
         PuedeIntentar = False
-        If acierto = 1 Then
-            intentosPesca(ContadorIntentosPescaEspecial_Fallados + ContadorIntentosPescaEspecial_Acertados) = 1
-        ElseIf acierto = 2 Then
-            intentosPesca(ContadorIntentosPescaEspecial_Fallados + ContadorIntentosPescaEspecial_Acertados) = 2
+        totalIntentos = ContadorIntentosPescaEspecial_Fallados + ContadorIntentosPescaEspecial_Acertados
+        If totalIntentos >= 1 And totalIntentos <= MAX_INTENTOS Then
+            intentosPesca(totalIntentos) = acierto
         End If
-        If ContadorIntentosPescaEspecial_Fallados + ContadorIntentosPescaEspecial_Acertados >= 5 Or ContadorIntentosPescaEspecial_Acertados >= 3 Then
-            PescandoEspecial = False
-            Call WriteFinalizarPescaEspecial
-        ElseIf ContadorIntentosPescaEspecial_Acertados >= 3 Then
-            PescandoEspecial = False
-            Call WriteFinalizarPescaEspecial
-        ElseIf ContadorIntentosPescaEspecial_Fallados >= 3 Then
+        PescaInputPauseUntil = tickActual + RandomNumber(500, 1501)
+        PescaPendienteReanudarRandomDir = True
+        If ContadorIntentosPescaEspecial_Fallados >= 3 Then
             PescandoEspecial = False
             Call AddtoRichTextBox(frmMain.RecTxt, JsonLanguage.Item("MENSAJE_PEZ_ROMPIO_LINEA_PESCA"), 255, 0, 0, 1, 0)
             Call WriteRomperCania
+        ElseIf totalIntentos >= MAX_INTENTOS Or ContadorIntentosPescaEspecial_Acertados >= 3 Then
+            PescandoEspecial = False
+            Call WriteFinalizarPescaEspecial
         End If
     End If
 End Function

--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -5697,6 +5697,10 @@ Public Sub HandlePelearConPezEspecial()
         intentosPesca(i) = 0
     Next i
     PescandoEspecial = True
+    PuedeIntentar = False
+    PescaInputPauseUntil = 0
+    PescaPendienteReanudarRandomDir = False
+    Call RandomizarParametrosPescaEspecial
     Call ao20audio.PlayWav(55)
     ContadorIntentosPescaEspecial_Fallados = 0
     ContadorIntentosPescaEspecial_Acertados = 0

--- a/CODIGO/TileEngine.bas
+++ b/CODIGO/TileEngine.bas
@@ -39,9 +39,14 @@ Public Const MAX_INTENTOS                      As Byte = 5
 Public intentosPesca(1 To MAX_INTENTOS)        As Byte
 Public PuedeIntentar                           As Boolean
 Public PescandoEspecial                        As Boolean
+Public PescaInputPauseUntil                    As Long
+Public PescaPendienteReanudarRandomDir         As Boolean
 Public MostrarTutorial                         As Boolean
 Public Const BarWidth                          As Long = 199
 Public PosicionBarra                           As Single
+Public CentroZonaAciertoPesca                  As Long
+Public RadioZonaAciertoPesca                   As Long
+Public VelocidadFactorBarraPesca               As Single
 Public ContadorIntentosPescaEspecial_Acertados As Long
 Public ContadorIntentosPescaEspecial_Fallados  As Long
 Public startTimePezEspecial                    As Long

--- a/CODIGO/TileEngine_RenderScreen.bas
+++ b/CODIGO/TileEngine_RenderScreen.bas
@@ -584,19 +584,28 @@ Sub RenderScreen(ByVal center_x As Integer, _
             End If
         Next i
         If PosicionBarra <= 0 Then
+            PosicionBarra = 0
             DireccionBarra = 1
             PuedeIntentar = True
-        ElseIf PosicionBarra > 199 Then
+            Call RandomizarParametrosPescaEspecial
+        ElseIf PosicionBarra >= 199 Then
+            PosicionBarra = 199
             DireccionBarra = -1
             PuedeIntentar = True
+            Call RandomizarParametrosPescaEspecial
         End If
-        If PosicionBarra < 0 Then
-            PosicionBarra = 0
-        ElseIf PosicionBarra > 199 Then
-            PosicionBarra = 199
+        If GetTickCount() >= PescaInputPauseUntil Then
+            If PescaPendienteReanudarRandomDir Then
+                If RandomNumber(0, 2) = 0 Then
+                    DireccionBarra = -1
+                Else
+                    DireccionBarra = 1
+                End If
+                PescaPendienteReanudarRandomDir = False
+                Call RandomizarParametrosPescaEspecial
+            End If
+            PosicionBarra = PosicionBarra + (DireccionBarra * VelocidadBarra * VelocidadFactorBarraPesca * timerElapsedTime * 0.2)
         End If
-        '90 - 111 es incluido (saca el pecesito)
-        PosicionBarra = PosicionBarra + (DireccionBarra * VelocidadBarra * timerElapsedTime * 0.2)
         If (GetTickCount() - startTimePezEspecial) >= 20000 Then
             PescandoEspecial = False
             Call AddtoRichTextBox(frmMain.RecTxt, JsonLanguage.Item("MENSAJE_PEZ_ROMPIO_LINEA_PESCA"), 255, 0, 0, 1, 0)


### PR DESCRIPTION
### Motivation
- Make the special fishing minigame less deterministic by randomizing the success zone and bar speed and adding input pause/resume to account for input lag and timing variability.

### Description
- Added `RandomizarParametrosPescaEspecial` to `General.bas`, replaced the hardcoded success range in `IntentarObtenerPezEspecial` with `CentroZonaAciertoPesca`/`RadioZonaAciertoPesca`, and ensured attempts are recorded only within `MAX_INTENTOS` bounds.
- Introduced input timing controls with new globals `PescaInputPauseUntil` and `PescaPendienteReanudarRandomDir`, updated bar movement to respect the pause and to resume with a randomized direction and speed factor in `TileEngine_RenderScreen.bas`, and clamp `PosicionBarra` to valid limits.
- Initialized the new fishing state (`PuedeIntentar`, `PescaInputPauseUntil`, `PescaPendienteReanudarRandomDir`) and called `RandomizarParametrosPescaEspecial` when a special-fish encounter starts in `Protocol.HandlePelearConPezEspecial`.

### Testing
- Performed a full project build which completed successfully with no compile errors.
- Executed an automated smoke test exercising the special-fishing flow which verified bar movement, randomized parameters, attempt recording, and input-pause/resume behavior, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f8bbda488328a704cd7ae043fdf9)