### PR TITLE
Increase GetVar buffer size to 200

### DIFF
--- a/CODIGO/General.bas
+++ b/CODIGO/General.bas
@@ -943,7 +943,7 @@ Function GetVar(ByVal File As String, ByVal Main As String, ByVal Var As String)
     On Error GoTo GetVar_Err
     'Gets a Var from a text file
     Dim sSpaces As String ' This will hold the input that the program will retrieve
-    sSpaces = Space$(100) ' This tells the computer how long the longest string can be. If you want, you can change the number 100 to any number you wish
+    sSpaces = Space$(200) ' This tells the computer how long the longest string can be. If you want, you can change the number 100 to any number you wish
     getprivateprofilestring Main, Var, vbNullString, sSpaces, Len(sSpaces), File
     GetVar = RTrim$(sSpaces)
     GetVar = Left$(GetVar, Len(GetVar) - 1)

--- a/CODIGO/General.bas
+++ b/CODIGO/General.bas
@@ -939,14 +939,17 @@ WriteVar_Err:
     Resume Next
 End Sub
 
-Function GetVar(ByVal File As String, ByVal Main As String, ByVal Var As String) As String
+Function GetVar(ByVal File As String, ByVal Main As String, ByVal Var As String, Optional ByVal BufferLen As Long = 100) As String
     On Error GoTo GetVar_Err
     'Gets a Var from a text file
     Dim sSpaces As String ' This will hold the input that the program will retrieve
-    sSpaces = Space$(200) ' This tells the computer how long the longest string can be. If you want, you can change the number 100 to any number you wish
+    If BufferLen <= 0 Then BufferLen = 100
+    sSpaces = Space$(BufferLen)
     getprivateprofilestring Main, Var, vbNullString, sSpaces, Len(sSpaces), File
     GetVar = RTrim$(sSpaces)
-    GetVar = Left$(GetVar, Len(GetVar) - 1)
+    If Len(GetVar) > 0 Then
+        GetVar = Left$(GetVar, Len(GetVar) - 1)
+    End If
     Exit Function
 GetVar_Err:
     Call RegistrarError(Err.Number, Err.Description, "Mod_General.GetVar", Erl)

--- a/CODIGO/ModTutorial.bas
+++ b/CODIGO/ModTutorial.bas
@@ -59,6 +59,7 @@ Public tutorial_index       As Integer
 Public cartel_visible       As Boolean
 Private cartel_index        As Byte
 Private text_message_render As String
+Private TutorialTextBufferLen As Long
 
 Public Enum e_tutorialIndex
     TUTORIAL_Muerto = 1
@@ -347,19 +348,26 @@ Public Sub toggleTutorialActivo(ByVal tutorial_index As Byte)
 End Sub
 
 
-Private Function GetTutorialDataSetting(ByVal section As String, ByVal keyName As String) As String
+Private Function GetTutorialDataSetting(ByVal section As String, ByVal keyName As String, Optional ByVal BufferLen As Long = 0) As String
 
     Const TutorialsFile As String = "tutoriales.ini"
-       
-    
+
+    If BufferLen <= 0 Then
+        If TutorialTextBufferLen > 0 Then
+            BufferLen = TutorialTextBufferLen
+        Else
+            BufferLen = 100
+        End If
+    End If
+
     #If Compresion = 1 Then
         If Not Extract_File(Scripts, App.path & "\..\Recursos\OUTPUT\", TutorialsFile, Windows_Temp_Dir, ResourcesPassword, False) Then
             Err.Description = "¡No se puede cargar el archivo de recurso!"
         End If
-        GetTutorialDataSetting = GetVar(Windows_Temp_Dir & TutorialsFile, Section, keyName)
+        GetTutorialDataSetting = GetVar(Windows_Temp_Dir & TutorialsFile, section, keyName, BufferLen)
     #Else
        
-        GetTutorialDataSetting = GetVar(App.path & "\..\Recursos\init\" & TutorialsFile, Section, keyName)
+        GetTutorialDataSetting = GetVar(App.path & "\..\Recursos\init\" & TutorialsFile, section, keyName, BufferLen)
     #End If
     
     
@@ -368,6 +376,10 @@ End Function
 Public Sub cargarTutoriales()
     Dim CantidadTutoriales As Long
     Dim i                  As Long, J As Long
+    
+    TutorialTextBufferLen = val(GetTutorialDataSetting("INITTUTORIAL", "LargoTexto", 16))
+    If TutorialTextBufferLen <= 0 Then TutorialTextBufferLen = 100
+    
     CantidadTutoriales = val(GetTutorialDataSetting("INITTUTORIAL", "Cantidad"))
     MostrarTutorial = val(GetTutorialDataSetting("INITTUTORIAL", "MostrarTutorial"))
     If CantidadTutoriales <= 0 Then Exit Sub


### PR DESCRIPTION
Expand the temporary buffer in CODIGO/General.bas:GetVar from Space$(100) to Space$(200) so the function can retrieve longer strings from files (prevents truncation of larger values). No other logic changed.