### PR TITLE
WIP Toggle NPC body by click and proximity

### DIFF
--- a/CODIGO/ModGameplayUI.bas
+++ b/CODIGO/ModGameplayUI.bas
@@ -72,6 +72,8 @@ Public Sub OnClick(ByVal MouseButton As Long, ByVal MouseShift As Long)
         End If
     End If
     Dim MouseAction As e_MouseAction
+    Call ToggleNpcType1BodyOnClick(tX, tY)
+
     Select Case MouseButton
         Case vbLeftButton
             MouseAction = ACCION1
@@ -228,6 +230,45 @@ Public Sub OnClick(ByVal MouseButton As Long, ByVal MouseShift As Long)
 OnClick_Err:
     Call RegistrarError(Err.Number, Err.Description, "ModGameplayUi.OnClick", Erl)
     Resume Next
+End Sub
+
+
+Private Sub ToggleNpcType1BodyOnClick(ByVal clickX As Byte, ByVal clickY As Byte)
+    On Error GoTo ToggleNpcType1BodyOnClick_Err
+
+    Dim charindex As Integer
+    charindex = MapData(clickX, clickY).charindex
+    If charindex = 0 And clickY < YMaxMapSize Then
+        charindex = MapData(clickX, clickY + 1).charindex
+    End If
+    If charindex = 0 Then Exit Sub
+
+    With charlist(charindex)
+        If Not .EsNpc Then Exit Sub
+        If .NPCNumber <= 0 Or .NPCNumber > UBound(NpcData) Then Exit Sub
+        If NpcData(.NPCNumber).NpcType <> 1 Then Exit Sub
+        If .BodyOnLand <= 0 Or .BodyIdle <= 0 Then Exit Sub
+
+        If .Body.Walk(.Heading).GrhIndex = BodyData(.BodyIdle).Walk(.Heading).GrhIndex Then
+            .Body = BodyData(.BodyOnLand)
+            .iBody = .BodyOnLand
+        Else
+            .Body = BodyData(.BodyIdle)
+            .iBody = .BodyIdle
+        End If
+
+        If .Body.AnimateOnIdle = 0 Then
+            .Body.Walk(.Heading).Loops = 0
+            .Body.Walk(.Heading).started = 0
+        Else
+            .Body.Walk(.Heading).Loops = 1
+            .Body.Walk(.Heading).started = FrameTime
+        End If
+    End With
+    Exit Sub
+
+ToggleNpcType1BodyOnClick_Err:
+    Call RegistrarError(Err.Number, Err.Description, "ModGameplayUI.ToggleNpcType1BodyOnClick", Erl)
 End Sub
 
 Public Sub HandleQuestionResponse(ByVal Result As Boolean)

--- a/CODIGO/engine.bas
+++ b/CODIGO/engine.bas
@@ -1305,6 +1305,7 @@ Sub Char_Render(ByVal charindex As Long, ByVal PixelOffsetX As Integer, ByVal Pi
     Dim terrainHeight    As Integer
     With charlist(charindex)
         If .Heading = 0 Then Exit Sub
+
         ' --- ESTADO IDLE AL COMIENZO DEL FRAME ---
         If Not .Moving And Not .TranslationActive And .Idle And .scrollDirectionX = 0 And .scrollDirectionY = 0 And .MoveOffsetX = 0 And .MoveOffsetY = 0 Then
             If .Body.AnimateOnIdle = 0 Then
@@ -1508,6 +1509,34 @@ Sub Char_Render(ByVal charindex As Long, ByVal PixelOffsetX As Integer, ByVal Pi
         Else
             ease = 0
         End If
+        Dim desiredNpcBody As Integer
+        desiredNpcBody = 0
+        If .EsNpc And Not .Muerto And Not .AnimatingBody And Not .Moving And Not .TranslationActive Then
+            If .NPCNumber > 0 And .NPCNumber <= UBound(NpcData) Then
+                If NpcData(.NPCNumber).NpcType = 17 And .BodyOnLand > 0 And Not IsAmphibianOverWater(charindex) Then
+                    Dim proximityRange As Integer
+                    proximityRange = 3
+
+                    desiredNpcBody = .BodyOnLand
+                    If distance(UserPos.x - AddtoUserPos.x, UserPos.y - AddtoUserPos.y, .pos.x, .pos.y) <= proximityRange And .BodyIdle > 0 Then
+                        desiredNpcBody = .BodyIdle
+                    End If
+                End If
+            End If
+        End If
+        If desiredNpcBody > 0 Then
+            If .Body.Walk(.Heading).GrhIndex <> BodyData(desiredNpcBody).Walk(.Heading).GrhIndex Then
+                .Body = BodyData(desiredNpcBody)
+                If .Body.AnimateOnIdle = 0 Then
+                    .Body.Walk(.Heading).Loops = 0
+                    .Body.Walk(.Heading).started = 0
+                Else
+                    .Body.Walk(.Heading).Loops = 1
+                    .Body.Walk(.Heading).started = FrameTime
+                End If
+            End If
+        End If
+
         If .Body.Walk(.Heading).GrhIndex Then
             If UserCiego Then
                 MostrarNombre = False


### PR DESCRIPTION
Add interactive and proximity-driven NPC body switching. ModGameplayUI: call new ToggleNpcType1BodyOnClick from OnClick and implement that helper to toggle NPC-type-1 characters between BodyOnLand and BodyIdle when clicked (with validation, animation state setup and error logging). engine: add an early exit when Heading = 0 in Char_Render and implement proximity-based body switching for NPC type 17 (range 3) so NPCs swap between on-land and idle bodies depending on user distance and amphibian/water status, updating animation loops/timers when the body changes.