### PR TITLE
WIP Toggle and auto-switch NPC body states

### DIFF
--- a/CODIGO/ModGameplayUI.bas
+++ b/CODIGO/ModGameplayUI.bas
@@ -72,6 +72,8 @@ Public Sub OnClick(ByVal MouseButton As Long, ByVal MouseShift As Long)
         End If
     End If
     Dim MouseAction As e_MouseAction
+    Call ToggleNpcType1BodyOnClick(tX, tY)
+
     Select Case MouseButton
         Case vbLeftButton
             MouseAction = ACCION1
@@ -228,6 +230,50 @@ Public Sub OnClick(ByVal MouseButton As Long, ByVal MouseShift As Long)
 OnClick_Err:
     Call RegistrarError(Err.Number, Err.Description, "ModGameplayUi.OnClick", Erl)
     Resume Next
+End Sub
+
+
+Private Sub ToggleNpcType1BodyOnClick(ByVal clickX As Byte, ByVal clickY As Byte)
+    On Error GoTo ToggleNpcType1BodyOnClick_Err
+
+    Dim charindex As Integer
+
+    If clickX < XMinMapSize Or clickX > XMaxMapSize Or clickY < YMinMapSize Or clickY > YMaxMapSize Then
+        Exit Sub
+    End If
+
+    charindex = MapData(clickX, clickY).charindex
+    If charindex = 0 And clickY < YMaxMapSize Then
+        If clickY + 1 >= YMinMapSize And clickY + 1 <= YMaxMapSize Then
+            charindex = MapData(clickX, clickY + 1).charindex
+        End If
+    End If
+    If charindex = 0 Then Exit Sub
+
+    With charlist(charindex)
+        If Not .EsNpc Then Exit Sub
+        If .NpcNumber <= 0 Or .NpcNumber > UBound(NpcData) Then Exit Sub
+        If NpcData(.NpcNumber).NpcType <> 1 Then Exit Sub
+        If .BodyOnLand <= 0 Or .BodyIdle <= 0 Then Exit Sub
+
+        If .Body.Walk(.Heading).GrhIndex = BodyData(.BodyIdle).Walk(.Heading).GrhIndex Then
+            .Body = BodyData(.BodyOnLand)
+            .iBody = .BodyOnLand
+            .AnimatingBody = False
+            .Body.Walk(.Heading).Loops = 0
+            .Body.Walk(.Heading).started = 0
+        Else
+            .Body = BodyData(.BodyIdle)
+            .iBody = .BodyOnLand
+            .AnimatingBody = True
+            .Body.Walk(.Heading).Loops = 1
+            .Body.Walk(.Heading).started = FrameTime
+        End If
+    End With
+    Exit Sub
+
+ToggleNpcType1BodyOnClick_Err:
+    Call RegistrarError(Err.Number, Err.Description, "ModGameplayUI.ToggleNpcType1BodyOnClick", Erl)
 End Sub
 
 Public Sub HandleQuestionResponse(ByVal Result As Boolean)

--- a/CODIGO/engine.bas
+++ b/CODIGO/engine.bas
@@ -1305,6 +1305,7 @@ Sub Char_Render(ByVal charindex As Long, ByVal PixelOffsetX As Integer, ByVal Pi
     Dim terrainHeight    As Integer
     With charlist(charindex)
         If .Heading = 0 Then Exit Sub
+
         ' --- ESTADO IDLE AL COMIENZO DEL FRAME ---
         If Not .Moving And Not .TranslationActive And .Idle And .scrollDirectionX = 0 And .scrollDirectionY = 0 And .MoveOffsetX = 0 And .MoveOffsetY = 0 Then
             If .Body.AnimateOnIdle = 0 Then
@@ -1508,6 +1509,52 @@ Sub Char_Render(ByVal charindex As Long, ByVal PixelOffsetX As Integer, ByVal Pi
         Else
             ease = 0
         End If
+        Dim desiredNpcBody As Integer
+        desiredNpcBody = 0
+        If .EsNpc And Not .Muerto And Not .AnimatingBody And Not .Moving And Not .TranslationActive Then
+            If .NpcNumber > 0 And .NpcNumber <= UBound(NpcData) Then
+                If NpcData(.NpcNumber).NpcType = 17 And .BodyOnLand > 0 And Not IsAmphibianOverWater(charindex) Then
+                    Dim proximityRange As Integer
+                    proximityRange = 3
+
+                    desiredNpcBody = .BodyOnLand
+                    If distance(UserPos.x - AddtoUserPos.x, UserPos.y - AddtoUserPos.y, .Pos.x, .Pos.y) <= proximityRange And .BodyIdle > 0 Then
+                        desiredNpcBody = .BodyIdle
+                    End If
+                End If
+            End If
+        End If
+        If desiredNpcBody > 0 Then
+            Dim desiredBodyGrh As Long
+            Dim desiredIdleGrh As Long
+            desiredBodyGrh = BodyData(desiredNpcBody).Walk(.Heading).GrhIndex
+            desiredIdleGrh = 0
+            If BodyData(desiredNpcBody).IdleBody > 0 Then
+                If BodyData(desiredNpcBody).IdleBody <= UBound(BodyData) Then
+                    desiredIdleGrh = BodyData(BodyData(desiredNpcBody).IdleBody).Walk(.Heading).GrhIndex
+                End If
+            End If
+
+            If .Body.Walk(.Heading).GrhIndex <> desiredBodyGrh And (desiredIdleGrh = 0 Or .Body.Walk(.Heading).GrhIndex <> desiredIdleGrh) Then
+                .Body = BodyData(desiredNpcBody)
+                If desiredNpcBody = .BodyIdle Then
+                    .iBody = .BodyOnLand
+                    .AnimatingBody = True
+                    .Body.Walk(.Heading).Loops = 1
+                    .Body.Walk(.Heading).started = FrameTime
+                Else
+                    .AnimatingBody = False
+                    If .Body.AnimateOnIdle = 0 Then
+                        .Body.Walk(.Heading).Loops = 0
+                        .Body.Walk(.Heading).started = 0
+                    Else
+                        .Body.Walk(.Heading).Loops = 0
+                        .Body.Walk(.Heading).started = FrameTime
+                    End If
+                End If
+            End If
+        End If
+
         If .Body.Walk(.Heading).GrhIndex Then
             If UserCiego Then
                 MostrarNombre = False


### PR DESCRIPTION
Add click toggle for NPC type 1 bodies and auto-switch NPC bodies by proximity. ModGameplayUI.bas: call ToggleNpcType1BodyOnClick from OnClick and implement ToggleNpcType1BodyOnClick to flip an NPC's Body between BodyOnLand and BodyIdle when clicked (with bounds/validation and error logging). engine.bas: extend Char_Render to choose a desiredNpcBody for certain NPCs (type 17) based on player proximity and water checks, then switch .Body and update .iBody, .AnimatingBody and Walk timing/loops accordingly to ensure correct animation state. Includes guard checks for indices and animation flags.