### PR TITLE
Add structured NPC drop system and UI display

### DIFF
--- a/CODIGO/ModUtils.bas
+++ b/CODIGO/ModUtils.bas
@@ -237,9 +237,7 @@ Public Type NpcDatas
     MinHit As Integer
     MaxHit As Integer
     Head As Integer
-    NumQuiza As Byte
     DropCount As Integer
-    QuizaDropea() As Integer
     DropObj() As Integer
     DropChance() As Integer
     DropMinAmount() As Integer

--- a/CODIGO/ModUtils.bas
+++ b/CODIGO/ModUtils.bas
@@ -238,7 +238,12 @@ Public Type NpcDatas
     MaxHit As Integer
     Head As Integer
     NumQuiza As Byte
+    DropCount As Integer
     QuizaDropea() As Integer
+    DropObj() As Integer
+    DropChance() As Integer
+    DropMinAmount() As Integer
+    DropMaxAmount() As Integer
     ExpClan As Long
     PuedeInvocar As Byte
     NoMapInfo As Byte

--- a/CODIGO/Recursos.bas
+++ b/CODIGO/Recursos.bas
@@ -1389,19 +1389,6 @@ Public Sub CargarIndicesOBJ()
         NpcData(Npc).BodyIdle = val(Leer.GetValue("npc" & Npc, "BodyIdle"))
         NpcData(Npc).DisabledInBattleServer = val(Leer.GetValue("npc" & Npc, "DisabledInBattleServer"))
         NpcData(Npc).Amphibian = val(Leer.GetValue("npc" & Npc, "Amphibian")) > 0
-        NpcData(Npc).QuizaProb = val(Leer.GetValue("npc" & Npc, "QuizaProb"))
-        
-        aux = val(Leer.GetValue("npc" & Npc, "NumQuiza"))
-        If aux = 0 Then
-            NpcData(Npc).NumQuiza = 0
-        Else
-            NpcData(Npc).NumQuiza = val(aux)
-            ReDim NpcData(Npc).QuizaDropea(1 To NpcData(Npc).NumQuiza) As Integer
-            For loopC = 1 To NpcData(Npc).NumQuiza
-                NpcData(Npc).QuizaDropea(loopC) = val(Leer.GetValue("npc" & Npc, "QuizaDropea" & loopC))
-                ' frmdebug.add_text_tracebox NpcData(Npc).QuizaDropea(loopc)
-            Next loopC
-        End If
         If NpcData(Npc).DropCount > 0 Then
             ReDim NpcData(Npc).DropObj(1 To NpcData(Npc).DropCount) As Integer
             ReDim NpcData(Npc).DropChance(1 To NpcData(Npc).DropCount) As Integer
@@ -1420,7 +1407,6 @@ Public Sub CargarIndicesOBJ()
                 End If
             Next loopC
         End If
-        If NpcData(Npc).DropCount <= 0 Then NpcData(Npc).DropCount = NpcData(Npc).NumQuiza
         
         ' Leer NroItems y sus Obj()
         aux = val(Leer.GetValue("npc" & Npc, "NROITEMS"))

--- a/CODIGO/Recursos.bas
+++ b/CODIGO/Recursos.bas
@@ -1378,6 +1378,7 @@ Public Sub CargarIndicesOBJ()
         NpcData(Npc).PuedeInvocar = val(Leer.GetValue("npc" & Npc, "PuedeInvocar"))
         NpcData(Npc).ElementalTags = val(Leer.GetValue("npc" & Npc, "ElementalTags"))
         NpcData(Npc).NpcType = val(Leer.GetValue("npc" & Npc, "NpcType"))
+        NpcData(Npc).DropCount = val(Leer.GetValue("npc" & Npc, "DropCount"))
         NpcData(Npc).Comercia = val(Leer.GetValue("npc" & Npc, "Comercia"))
         NpcData(Npc).level = val(Leer.GetValue("npc" & Npc, "Nivel"))
         NpcData(Npc).WaterAttackAnimation = val(Leer.GetValue("npc" & Npc, "Ataque2"))
@@ -1401,6 +1402,25 @@ Public Sub CargarIndicesOBJ()
                 ' frmdebug.add_text_tracebox NpcData(Npc).QuizaDropea(loopc)
             Next loopC
         End If
+        If NpcData(Npc).DropCount > 0 Then
+            ReDim NpcData(Npc).DropObj(1 To NpcData(Npc).DropCount) As Integer
+            ReDim NpcData(Npc).DropChance(1 To NpcData(Npc).DropCount) As Integer
+            ReDim NpcData(Npc).DropMinAmount(1 To NpcData(Npc).DropCount) As Integer
+            ReDim NpcData(Npc).DropMaxAmount(1 To NpcData(Npc).DropCount) As Integer
+            Dim dropValue As String
+            Dim dropParts() As String
+            For loopC = 1 To NpcData(Npc).DropCount
+                dropValue = Trim$(Leer.GetValue("npc" & Npc, "Drop" & loopC))
+                If Len(dropValue) > 0 Then
+                    dropParts = Split(dropValue, "-")
+                    If UBound(dropParts) >= 0 Then NpcData(Npc).DropObj(loopC) = Val(dropParts(0))
+                    If UBound(dropParts) >= 1 Then NpcData(Npc).DropChance(loopC) = Val(dropParts(1))
+                    If UBound(dropParts) >= 2 Then NpcData(Npc).DropMinAmount(loopC) = Val(dropParts(2))
+                    If UBound(dropParts) >= 3 Then NpcData(Npc).DropMaxAmount(loopC) = Val(dropParts(3))
+                End If
+            Next loopC
+        End If
+        If NpcData(Npc).DropCount <= 0 Then NpcData(Npc).DropCount = NpcData(Npc).NumQuiza
         
         ' Leer NroItems y sus Obj()
         aux = val(Leer.GetValue("npc" & Npc, "NROITEMS"))

--- a/CODIGO/frmMapaGrande.frm
+++ b/CODIGO/frmMapaGrande.frm
@@ -743,7 +743,7 @@ Private Sub ListView1_ItemClick(ByVal Item As MSComctlLib.ListItem)
         Call DibujarNPC(Me.PlayerView, .Head, .Body)
         
         ' --- Drops ---
-        If .NumQuiza > 0 Or .NpcType = 0 And (.NroItems > 0 And .Comercia < 1) Then
+        If .NumQuiza > 0 Or .DropCount > 0 Or .NpcType = 0 And (.NroItems > 0 And .Comercia < 1) Then
             Dim i As Integer, objIdx As Long
             Dim subelemento As ListItem
         
@@ -755,6 +755,15 @@ Private Sub ListView1_ItemClick(ByVal Item As MSComctlLib.ListItem)
                         Set subelemento = listdrop.ListItems.Add(, , ObjData(objIdx).Name)
                         subelemento.SubItems(1) = CStr(ObjData(objIdx).GrhIndex)
                         subelemento.Tag = GetNpcDropPercentage(.QuizaProb, .NumQuiza)
+                    End If
+                Next i
+            ElseIf .DropCount > 0 Then
+                For i = 1 To .DropCount
+                    objIdx = .DropObj(i)
+                    If objIdx > 0 Then
+                        Set subelemento = listdrop.ListItems.Add(, , ObjData(objIdx).Name)
+                        subelemento.SubItems(1) = CStr(ObjData(objIdx).GrhIndex)
+                        subelemento.Tag = GetNpcDropPercentageFromDenominator(.DropChance(i))
                     End If
                 Next i
             End If
@@ -1196,19 +1205,28 @@ txtSearchMap_KeyPress_Err:
 End Sub
 Private Function GetNpcDropPercentage(ByVal QuizaProb As Integer, ByVal NumQuiza As Integer) As Double
 On Error GoTo GetNpcDropPercentage_Err
-    If QuizaProb <= 0 Then
+    If QuizaProb <= 0 Or NumQuiza <= 0 Then
         GetNpcDropPercentage = 0
         Exit Function
     End If
     
-    If NumQuiza <= 0 Then
-        GetNpcDropPercentage = 0
-        Exit Function
-    End If
-    
-    GetNpcDropPercentage = Round((1 / QuizaProb * 100) / NumQuiza, 2)
+    GetNpcDropPercentage = Round((100# * NumQuiza) / QuizaProb, 2)
     Exit Function
 GetNpcDropPercentage_Err:
     Call RegistrarError(Err.Number, Err.Description, "frmMapaGrande.GetNpcDropPercentage", Erl)
+    Resume Next
+End Function
+
+Private Function GetNpcDropPercentageFromDenominator(ByVal Denominator As Integer) As Double
+On Error GoTo GetNpcDropPercentageFromDenominator_Err
+    If Denominator <= 0 Then
+        GetNpcDropPercentageFromDenominator = 0
+        Exit Function
+    End If
+    
+    GetNpcDropPercentageFromDenominator = Round(100# / Denominator, 2)
+    Exit Function
+GetNpcDropPercentageFromDenominator_Err:
+    Call RegistrarError(Err.Number, Err.Description, "frmMapaGrande.GetNpcDropPercentageFromDenominator", Erl)
     Resume Next
 End Function

--- a/CODIGO/frmMapaGrande.frm
+++ b/CODIGO/frmMapaGrande.frm
@@ -663,7 +663,6 @@ Private Sub listdrop_Click()
     On Error GoTo listdrop_Click_Err
     picture1.BackColor = vbBlack
     picture1.Refresh
-    'Call Grh_Render_To_Hdc(Picture1, ObjData(NpcData(ListView1.SelectedItem.SubItems(2)).QuizaDropea(listdrop.SelectedItem.Index)).grhindex, 0, 0, False)
     If listdrop.ListItems.count <= 0 Then Exit Sub
     Call Grh_Render_To_Hdc(picture1, listdrop.SelectedItem.SubItems(1), 0, 0, False)
     
@@ -743,21 +742,11 @@ Private Sub ListView1_ItemClick(ByVal Item As MSComctlLib.ListItem)
         Call DibujarNPC(Me.PlayerView, .Head, .Body)
         
         ' --- Drops ---
-        If .NumQuiza > 0 Or .DropCount > 0 Or .NpcType = 0 And (.NroItems > 0 And .Comercia < 1) Then
+        If .DropCount > 0 Or .NpcType = 0 And (.NroItems > 0 And .Comercia < 1) Then
             Dim i As Integer, objIdx As Long
             Dim subelemento As ListItem
         
-            ' --- Si tiene drop por QuizaDropea ---
-            If .NumQuiza > 0 Then
-                For i = 1 To .NumQuiza
-                    objIdx = .QuizaDropea(i)
-                    If objIdx > 0 Then
-                        Set subelemento = listdrop.ListItems.Add(, , ObjData(objIdx).Name)
-                        subelemento.SubItems(1) = CStr(ObjData(objIdx).GrhIndex)
-                        subelemento.Tag = GetNpcDropPercentage(.QuizaProb, .NumQuiza)
-                    End If
-                Next i
-            ElseIf .DropCount > 0 Then
+            If .DropCount > 0 Then
                 For i = 1 To .DropCount
                     objIdx = .DropObj(i)
                     If objIdx > 0 Then
@@ -1203,19 +1192,7 @@ txtSearchMap_KeyPress_Err:
     Call RegistrarError(Err.Number, Err.Description, "frmMapaGrande.txtSearchMap_KeyPress", Erl)
     Resume Next
 End Sub
-Private Function GetNpcDropPercentage(ByVal QuizaProb As Integer, ByVal NumQuiza As Integer) As Double
-On Error GoTo GetNpcDropPercentage_Err
-    If QuizaProb <= 0 Or NumQuiza <= 0 Then
-        GetNpcDropPercentage = 0
-        Exit Function
-    End If
-    
-    GetNpcDropPercentage = Round((100# * NumQuiza) / QuizaProb, 2)
-    Exit Function
-GetNpcDropPercentage_Err:
-    Call RegistrarError(Err.Number, Err.Description, "frmMapaGrande.GetNpcDropPercentage", Erl)
-    Resume Next
-End Function
+
 
 Private Function GetNpcDropPercentageFromDenominator(ByVal Denominator As Integer) As Double
 On Error GoTo GetNpcDropPercentageFromDenominator_Err


### PR DESCRIPTION
Introduce explicit NPC drop fields and display logic.

- ModUtils: Add DropCount and arrays (DropObj, DropChance, DropMinAmount, DropMaxAmount) to NpcDatas to represent individual drops.
- Recursos: Load DropCount from resource and parse Drop1..DropN into the new arrays; if DropCount <= 0, fall back to NumQuiza for compatibility.
- frmMapaGrande: Update drop display logic to show entries from the new Drop arrays when DropCount > 0; keep existing Quiza-based behavior otherwise. Add a new helper GetNpcDropPercentageFromDenominator and simplify GetNpcDropPercentage; add error logging in both functions.

These changes allow defining per-item drop entries with chance and amount ranges, and expose them in the map UI.