### PR TITLE
fix(client): restore double-click throttle

### DIFF
--- a/CODIGO/Protocol_Writes.bas
+++ b/CODIGO/Protocol_Writes.bas
@@ -904,6 +904,10 @@ Public Sub WriteDoubleClick(ByVal x As Byte, ByVal y As Byte)
 
     On Error GoTo WriteDoubleClick_Err
 
+    If ShouldBlockAction(eActionRateLimitType.ActionLeftClick) Then
+        Exit Sub
+    End If
+
     Call Writer.WriteInt16(ClientPacketID.eDoubleClick)
     Call Writer.WriteInt8(x)
     Call Writer.WriteInt8(y)


### PR DESCRIPTION
Restored double-click throttle to prevent server-kick, aligning to the new left-click-only mechanic for world interactions.