### PR TITLE
Sanitize input in RemoveFirstThreeIfUnderscore

### DIFF
--- a/CODIGO/clsAudioEngine.cls
+++ b/CODIGO/clsAudioEngine.cls
@@ -1191,14 +1191,17 @@ PlayFxUniqueByLabel_Error:
 End Sub
 
 Public Function RemoveFirstThreeIfUnderscore(ByVal s As String) As String
+    ' Ensure s is treated as a String
+    s = CStr(s)
+    
     ' Check for underscore anywhere in the string
-    If InStr(s, "_") > 0 Then
+    If InStr(1, s, "_", vbBinaryCompare) > 0 Then
         ' If the string is longer than 3 characters, strip off the first 3
         If Len(s) > 3 Then
             RemoveFirstThreeIfUnderscore = mid$(s, 4)
         Else
             ' If it's 3 characters or less, return an empty string
-            RemoveFirstThreeIfUnderscore = ""
+            RemoveFirstThreeIfUnderscore = vbNullString
         End If
     Else
         ' No underscore: return the original string


### PR DESCRIPTION
Cast input to String and make underscore detection explicit. Adds CStr(s) to ensure s is treated as a String, uses InStr(1, s, "_", vbBinaryCompare) for a reliable search, and returns vbNullString instead of an empty literal for short results. Behavior remains: if an underscore exists and length>3, strip first three characters; otherwise return original or empty-equivalent string. These changes reduce type-mismatch risk and ensure consistent string comparison.