### PR TITLE
Update Bodies/Graphics from PanelGM

### DIFF
--- a/CODIGO/General.bas
+++ b/CODIGO/General.bas
@@ -1150,11 +1150,12 @@ Public Sub CloseClient()
     ' Allow new instances of the client to be opened
     On Error GoTo CloseClient_Err
     UserSaliendo = True
+    prgRun = False
+    EngineRun = False
     Call SaveConfig
     Call UnloadAntiCheat
     Call PrevInstance.ReleaseInstance
     ao20audio.StopAllPlayback
-    EngineRun = False
     Call General_Set_Mouse_Speed(SensibilidadMouseOriginal)
     Call Resolution.ResetResolution
     Set SurfaceDB = Nothing

--- a/CODIGO/frmMain.frm
+++ b/CODIGO/frmMain.frm
@@ -2306,7 +2306,7 @@ Private Sub Form_QueryUnload(Cancel As Integer, UnloadMode As Integer)
     On Error GoTo Form_QueryUnload_Err
     If prgRun = True Then
         prgRun = False
-        Cancel = 1
+        ' Allow the unload to proceed immediately after stopping the main loop.
     End If
     Exit Sub
 Form_QueryUnload_Err:

--- a/CODIGO/frmPanelGm.frm
+++ b/CODIGO/frmPanelGm.frm
@@ -1684,6 +1684,14 @@ Begin VB.Form frmPanelgm
             Index           =   5
          End
          Begin VB.Menu mnuReload 
+            Caption         =   "Cuerpos"
+            Index           =   9
+         End
+         Begin VB.Menu mnuReload 
+            Caption         =   "Graficos"
+            Index           =   10
+         End
+         Begin VB.Menu mnuReload 
             Caption         =   "NPCs"
             Index           =   6
          End
@@ -2858,6 +2866,23 @@ mnuIP_Click_Err:
     Resume Next
 End Sub
 
+Private Sub mnuReload_Click(Index As Integer)
+    On Error GoTo mnuReload_Click_Err
+    Select Case Index
+        Case 9
+            Call CargarCuerpos
+            MsgBox "Archivo cuerpos.dat recargado.", vbInformation, "PanelGM"
+        Case 10
+            Call LoadGrhIni
+            MsgBox "Archivo Graficos.ini recargado.", vbInformation, "PanelGM"
+        Case Else
+            ' Otros valores de recarga pueden manejarse aquí si es necesario.
+    End Select
+    Exit Sub
+mnuReload_Click_Err:
+    Call RegistrarError(Err.Number, Err.Description, "frmPanelGM.mnuReload_Click", Erl)
+    Resume Next
+End Sub
 
 Private Sub MOTD_Click()
     On Error GoTo MOTD_Click_Err


### PR DESCRIPTION
Stop the running loop earlier during shutdown and add GM menu items to reload assets.

- CODIGO/General.bas: set prgRun = False and EngineRun = False earlier in CloseClient so the main loop and engine are flagged stopped before saving config, unloading anti-cheat and other cleanup.
- CODIGO/frmMain.frm: allow the form to unload immediately after stopping the main loop (removed Cancel = 1) so shutdown proceeds without waiting.
- CODIGO/frmPanelGm.frm: add two mnuReload menu entries (Cuerpos, Graficos) and implement mnuReload_Click to reload cuerpos.dat and Graficos.ini (calls CargarCuerpos and LoadGrhIni) with confirmation messages and error logging. This enables reloading assets at runtime from the GM panel.