### PR TITLE
feat(cliente): actualizar mensaje de marca de clan para NPCs

### DIFF
--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -3407,7 +3407,7 @@ Private Sub HandleWorkRequestTarget()
             Call AddtoRichTextBox(frmMain.RecTxt, JsonLanguage.Item("MENSAJE_TRABAJO_MAGIA"), 100, 100, 120, 0, 0)
             Call FormParser.Parse_Form(Frm, E_SHOOT)
         Case MarcaDeClan
-            Call AddtoRichTextBox(frmMain.RecTxt, JsonLanguage.Item("MENSAJE_SELECCIONA_PERSONAJE_A_MARCAR"), 100, 100, 120, 0, 0)
+            Call AddtoRichTextBox(frmMain.RecTxt, JsonLanguage.Item("MENSAJE_SELECCIONA_NPC_A_MARCAR"), 100, 100, 120, 0, 0)
             Call FormParser.Parse_Form(Frm, E_SHOOT)
         Case MarcaDeGM
             Call AddtoRichTextBox(frmMain.RecTxt, JsonLanguage.Item("MENSAJE_SELECCIONA_PERSONAJE_A_MARCAR"), 100, 100, 120, 0, 0)

--- a/Languages/1.json
+++ b/Languages/1.json
@@ -101,6 +101,7 @@
     "MENSAJE_SELECCIONA_PERSONAJE_A_MARCAR": "Seleccione el personaje que desea marcar...",
     "MENSAJE_SEGURO_RESURRECCION_ACTIVADO": "Seguro de resurrección activado.",
     "MENSAJE_SEGURO_RESURRECCION_DESACTIVADO": "Seguro de resurrección desactivado.",
+    "MENSAJE_SELECCIONA_NPC_A_MARCAR": "Selecciona el NPC a marcar para tu clan.",
     "MENSAJE_DEJAS_DE_TRABAJAR": "Has dejado de trabajar...",
     "MENSAJE_NO_TIENES_ORO_SUFICIENTE": "No tenés suficiente oro.",
     "MENSAJE_INFORMACION_DE_SKILL": "Información del skill> ",

--- a/Languages/2.json
+++ b/Languages/2.json
@@ -99,6 +99,7 @@
     "MENSAJE_SEGURO_CLAN_ACTIVADO": "Clan lock activated.",
     "MENSAJE_CLICK_DONDE_DESEAS_TRABAJAR": "Click where you want to work...",
     "MENSAJE_SELECCIONA_PERSONAJE_A_MARCAR": "Select the character you want to mark...",
+    "MENSAJE_SELECCIONA_NPC_A_MARCAR": "Select the NPC to mark for your clan.",
     "MENSAJE_SEGURO_RESURRECCION_ACTIVADO": "Resurrection lock activated.",
     "MENSAJE_SEGURO_RESURRECCION_DESACTIVADO": "Resurrection lock deactivated.",
     "MENSAJE_DEJAS_DE_TRABAJAR": "You have stopped working...",

--- a/Languages/3.json
+++ b/Languages/3.json
@@ -105,6 +105,7 @@
   "MENSAJE_NO_TIENES_ORO_SUFICIENTE": "Você não tem ouro suficiente.",
   "MENSAJE_INFORMACION_DE_SKILL": "Informação da habilidade> ",
   "MENSAJE_UBICACION_DE_COMPANERO": "Localização do seu companheiro de clã que solicita ajuda: (",
+  "MENSAJE_SELECCIONA_NPC_A_MARCAR": "Selecione o NPC para marcar para o seu clÃ£.",
   "MENSAJE_REMOVER_BAN": "Tem certeza que deseja remover o banimento do personagem ",
   "INPUTBOX_MOTIVO": "Motivo?",
   "INPUTBOX_TITULO": "Insira o motivo",

--- a/Languages/4.json
+++ b/Languages/4.json
@@ -102,6 +102,7 @@
   "MENSAJE_SEGURO_RESURRECCION_ACTIVADO": "Assurance de résurrection activée.",
   "MENSAJE_SEGURO_RESURRECCION_DESACTIVADO": "Assurance de résurrection désactivée.",
   "MENSAJE_DEJAS_DE_TRABAJAR": "Vous avez arrêté de travailler...",
+  "MENSAJE_SELECCIONA_NPC_A_MARCAR": "SÃ©lectionnez le NPC Ã  marquer pour votre clan.",
   "MENSAJE_NO_TIENES_ORO_SUFICIENTE": "Vous n'avez pas assez d'or.",
   "MENSAJE_INFORMACION_DE_SKILL": "Information de compétence> ",
   "MENSAJE_UBICACION_DE_COMPANERO": "Emplacement de votre compagnon de clan qui demande de l'aide : (",

--- a/Languages/5.json
+++ b/Languages/5.json
@@ -99,6 +99,7 @@
   "MENSAJE_SEGURO_CLAN_ACTIVADO": "Assicurazione clan attivata.",
   "MENSAJE_CLICK_DONDE_DESEAS_TRABAJAR": "Clicca dove desideri lavorare...",
   "MENSAJE_SELECCIONA_PERSONAJE_A_MARCAR": "Seleziona il personaggio che desideri marcare...",
+  "MENSAJE_SELECCIONA_NPC_A_MARCAR": "Seleziona il PNG da assegnare al tuo clan.",
   "MENSAJE_SEGURO_RESURRECCION_ACTIVADO": "Assicurazione di resurrezione attivata.",
   "MENSAJE_SEGURO_RESURRECCION_DESACTIVADO": "Assicurazione di resurrezione disattivata.",
   "MENSAJE_DEJAS_DE_TRABAJAR": "Hai smesso di lavorare...",


### PR DESCRIPTION
Se reemplaza el mensaje genérico "Selecciona el personaje a marcar" por la nueva clave MENSAJE_SELECCIONA_NPC_A_MARCAR en el Case MarcaDeClan de HandleWorkRequestTarget, para reflejar que ahora la marca apunta a NPCs. Se agrega la clave MENSAJE_SELECCIONA_NPC_A_MARCAR en los archivos de idioma: español, inglés, portugués, francés e italiano.