### PR TITLE
Add client-close flag to macro sanction calls and update sanction handler

### DIFF
--- a/CODIGO/frmPanelGm.frm
+++ b/CODIGO/frmPanelGm.frm
@@ -3272,7 +3272,7 @@ Public Sub CadenaChat(ByVal chat As String)
             nombre = Trim(nombre)
             If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(Cadena, "MacroTotal.txt")
             If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(Cadena, "MacroDePaquetes.txt")
-            If frmPanelgm.chkPaquetes.value = 1 Then Call AplicarSancionMacro(nombre, frmPanelgm.chkPaquetesCarcel.value = 1)
+            Call AplicarSancionMacro(nombre, frmPanelgm.chkPaquetes.value = 1, frmPanelgm.chkPaquetesCarcel.value = 1)
         End If
     End If
     ' Divide la cadena en partes utilizando "Control de macro---> El usuario" como separador
@@ -3301,7 +3301,7 @@ Public Sub CadenaChat(ByVal chat As String)
                             Dim TiempoActual As Single
                             TiempoActual = Timer
                             If TiempoActual - TiempoAnterior < frmPanelgm.txtSegundos Then
-                                If frmPanelgm.chkOcultar = 1 Then Call AplicarSancionMacro(nombre, frmPanelgm.chkOcultarCarcel.value = 1)
+                                Call AplicarSancionMacro(nombre, frmPanelgm.chkOcultar.value = 1, frmPanelgm.chkOcultarCarcel.value = 1)
                             End If
                             TiempoAnterior = TiempoActual
                         End If
@@ -3309,18 +3309,18 @@ Public Sub CadenaChat(ByVal chat As String)
                 Case InStr(Cadena, "UseItemU") > 0
                     If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(nombre & ",Macro de UsarItem U ", "MacroUseItemU.txt")
                     'Call ParseUserCommand("/MENSAJEINFORMACION " & nombre & "@" & "INFORMACION: Le recordamos que el uso de macros o programas externos está estrictamente prohibido y puede resultar en sanciones.")
-                    If frmPanelgm.chkUsarItem.value = 1 Then Call AplicarSancionMacro(nombre, frmPanelgm.chkUsarItemCarcel.value = 1)
+                    Call AplicarSancionMacro(nombre, frmPanelgm.chkUsarItem.value = 1, frmPanelgm.chkUsarItemCarcel.value = 1)
                 Case InStr(Cadena, "UseItem") > 0
                     If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(nombre & ",Macro de UsarItem ", "MacroUseItem.txt")
                     'Call ParseUserCommand("/MENSAJEINFORMACION " & nombre & "@" & "INFORMACION: Le recordamos que el uso de macros o programas externos está estrictamente prohibido y puede resultar en sanciones.")
-                    If frmPanelgm.chkUsarItem.value = 1 Then Call AplicarSancionMacro(nombre, frmPanelgm.chkUsarItemCarcel.value = 1)
+                    Call AplicarSancionMacro(nombre, frmPanelgm.chkUsarItem.value = 1, frmPanelgm.chkUsarItemCarcel.value = 1)
                 Case InStr(Cadena, "GuildMessage") > 0
                     If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(nombre & ",Macro de GuildMessage ", "MacroGuildMessage.txt")
                     'Call ParseUserCommand("/MENSAJEINFORMACION " & nombre & "@" & "INFORMACION: Le recordamos que el uso de macros o programas externos está estrictamente prohibido y puede resultar en sanciones.")
                 Case InStr(Cadena, "LeftClick") > 0
                     Resultado = GuardarTextoEnArchivo(nombre & ",Macro de LeftClick ", "MacroLeftClick.txt")
                     'Call ParseUserCommand("/MENSAJEINFORMACION " & nombre & "@" & "INFORMACION: Le recordamos que el uso de macros o programas externos está estrictamente prohibido y puede resultar en sanciones.")
-                    If frmPanelgm.chkLeftClick.value = 1 Then Call AplicarSancionMacro(nombre, frmPanelgm.chkLeftClickCarcel.value = 1)
+                    Call AplicarSancionMacro(nombre, frmPanelgm.chkLeftClick.value = 1, frmPanelgm.chkLeftClickCarcel.value = 1)
                 Case InStr(Cadena, "ChangeHeading") > 0
                     Resultado = GuardarTextoEnArchivo(nombre & ",Macro de ChangeHeading ", "MacroChangeHeading.txt")
                     'Call ParseUserCommand("/MENSAJEINFORMACION " & nombre & "@" & "INFORMACION: Le recordamos que el uso de macros o programas externos está estrictamente prohibido y puede resultar en sanciones.")
@@ -3349,19 +3349,19 @@ Public Sub CadenaChat(ByVal chat As String)
                 Case InStr(Cadena, "Macro de Cordenadas") > 0
                     If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(nombre & ",Macro de Cordenadas", "MacroCoordenadas.txt")
                     'Call ParseUserCommand("/MENSAJEINFORMACION " & nombre & "@" & "INFORMACION: Le recordamos que el uso de macros o programas externos está estrictamente prohibido y puede resultar en sanciones.")
-                    If frmPanelgm.chkCoordenadas.value = 1 Then Call AplicarSancionMacro(nombre, frmPanelgm.chkCoordenadasCarcel.value = 1)
+                    Call AplicarSancionMacro(nombre, frmPanelgm.chkCoordenadas.value = 1, frmPanelgm.chkCoordenadasCarcel.value = 1)
                 Case InStr(Cadena, ").") > 0
                     If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(nombre & ",Macro de click", "MacroDeClick.txt")
                     'Call ParseUserCommand("/MENSAJEINFORMACION " & nombre & "@" & "INFORMACION: Le recordamos que el uso de macros o programas externos está estrictamente prohibido y puede resultar en sanciones.")
-                    If frmPanelgm.chkClicks.value = 1 Then Call AplicarSancionMacro(nombre, frmPanelgm.chkClicksCarcel.value = 1)
+                    Call AplicarSancionMacro(nombre, frmPanelgm.chkClicks.value = 1, frmPanelgm.chkClicksCarcel.value = 1)
                 Case InStr(Cadena, "Macro Inasistido") > 0
                     If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(nombre & ",Macro Inasistido", "MacroInasistido.txt")
                     'Call ParseUserCommand("/MENSAJEINFORMACION " & nombre & "@" & "INFORMACION: Le recordamos que el uso de macros o programas externos está estrictamente prohibido y puede resultar en sanciones.")
-                    If frmPanelgm.chkInasistido.value = 1 Then Call AplicarSancionMacro(nombre, frmPanelgm.chkInasistidoCarcel.value = 1)
+                    Call AplicarSancionMacro(nombre, frmPanelgm.chkInasistido.value = 1, frmPanelgm.chkInasistidoCarcel.value = 1)
                 Case InStr(Cadena, "Macro de Carteleo") > 0
                     If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(nombre & ",Macro de Carteleo", "MacroCarteleo.txt")
                     'Call ParseUserCommand("/MENSAJEINFORMACION " & nombre & "@" & "INFORMACION: Le recordamos que el uso de macros o programas externos está estrictamente prohibido y puede resultar en sanciones.")
-                    If frmPanelgm.chkCarteleo.value = 1 Then Call AplicarSancionMacro(nombre, frmPanelgm.chkCarteleoCarcel.value = 1)
+                    Call AplicarSancionMacro(nombre, frmPanelgm.chkCarteleo.value = 1, frmPanelgm.chkCarteleoCarcel.value = 1)
                 Case Else
                     ' Manejar el caso en el que no hay coincidencias
             End Select
@@ -3391,7 +3391,7 @@ Public Sub CadenaChat(ByVal chat As String)
     End If
 End Sub
 
-Private Sub AplicarSancionMacro(ByVal nombre As String, ByVal mandarCarcel As Boolean)
+Private Sub AplicarSancionMacro(ByVal nombre As String, ByVal cerrarCliente As Boolean, ByVal mandarCarcel As Boolean)
     Dim tiempoCarcel As Long
 
     tiempoCarcel = CLng(val(frmPanelgm.txtTiempoCarcelMacros.Text))
@@ -3403,8 +3403,10 @@ Private Sub AplicarSancionMacro(ByVal nombre As String, ByVal mandarCarcel As Bo
 
     If mandarCarcel And Not EstaUsuarioEnMapa66(nombre) Then
         Call ParseUserCommand("/CARCEL " & nombre & "@Uso de programas externos, Macros o Cheat@" & tiempoCarcel)
-    Else
+    ElseIf cerrarCliente Then
         Call WriteCerraCliente(nombre)
+    Else
+        Call ParseUserCommand("/MENSAJEINFORMACION " & nombre & "@INFORMACION: Detectamos actividad sospechosa de macro. Esta accion fue registrada.")
     End If
 End Sub
 


### PR DESCRIPTION
### Motivation

- Unify and extend the macro sanction API to allow choosing between closing the client, sending the user to jail, or only logging an informational message when a macro is detected.

### Description

- Updated all calls to `AplicarSancionMacro` to pass two boolean flags: `cerrarCliente` (close client) and `mandarCarcel` (send to jail) instead of the previous single-flag call pattern.
- Changed the subroutine signature to `Private Sub AplicarSancionMacro(ByVal nombre As String, ByVal cerrarCliente As Boolean, ByVal mandarCarcel As Boolean)` and adjusted parameter handling accordingly.
- Revised sanction logic to prefer jailing when `mandarCarcel` is true and the user is not on map 66, otherwise close the client if `cerrarCliente` is true, and otherwise send an informational message to the user.
- Retained existing jail time bounds logic using `frmPanelgm.txtTiempoCarcelMacros.Text` with the same default and limits.

### Testing

- Performed an automated CI project build which compiled successfully. 
- Ran automated static/compile checks against the modified form file which passed without errors. 
- There are no existing automated unit tests for this legacy form code, so no unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a076faf3b248328873d6dca6201ae14)