### PR TITLE
Centralize Coord label updates with outline labels

### DIFF
--- a/CODIGO/ModGameplayUI.bas
+++ b/CODIGO/ModGameplayUI.bas
@@ -590,7 +590,7 @@ End Sub
 
 Public Sub UpdateMapPos()
     Call frmMain.SetMinimapPosition(0, UserPos.x, UserPos.y)
-    frmMain.Coord.Caption = UserMap & "-" & UserPos.x & "-" & UserPos.y
+    Call frmMain.SetCoordCaption(UserMap & "-" & UserPos.x & "-" & UserPos.y)
     If frmMapaGrande.visible Then
         Call frmMapaGrande.ActualizarPosicionMapa
     End If

--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -2172,9 +2172,9 @@ Private Sub HandleUserCharIndexInServer()
     UpdatePlayerRoof
     lastMove = FrameTime
     If MapDat.Seguro = 1 Then
-        frmMain.Coord.ForeColor = RGB(0, 170, 0)
+        Call frmMain.SetCoordColor(RGB(0, 170, 0))
     Else
-        frmMain.Coord.ForeColor = RGB(170, 0, 0)
+        Call frmMain.SetCoordColor(RGB(170, 0, 0))
     End If
     Call UpdateMapPos
     g_game_state.state = e_state_gameplay_screen
@@ -2449,9 +2449,9 @@ Private Sub HandleForceCharMove()
     Call MoveScreen(direccion)
     Call UpdateMapPos
     If MapDat.Seguro = 1 Then
-        frmMain.Coord.ForeColor = RGB(0, 170, 0)
+        Call frmMain.SetCoordColor(RGB(0, 170, 0))
     Else
-        frmMain.Coord.ForeColor = RGB(170, 0, 0)
+        Call frmMain.SetCoordColor(RGB(170, 0, 0))
     End If
     Call RefreshAllChars
     Exit Sub

--- a/CODIGO/TileEngine_Map.bas
+++ b/CODIGO/TileEngine_Map.bas
@@ -85,7 +85,7 @@ Sub SwitchMap(ByVal map As Integer, Optional ByVal NewResourceMap As Integer = 0
         Call ao20audio.PlayAmbientAudio(map)
     End If
     If MapDat.Seguro = 1 Then
-        frmMain.Coord.ForeColor = RGB(0, 170, 0)
+        Call frmMain.SetCoordColor(RGB(0, 170, 0))
     Else
         If MostrarTutorial And tutorial_index <= 0 And isLogged Then
             If tutorial(e_tutorialIndex.TUTORIAL_ZONA_INSEGURA).Activo = 1 Then
@@ -95,7 +95,7 @@ Sub SwitchMap(ByVal map As Integer, Optional ByVal NewResourceMap As Integer = 0
                         535, 640, 530, 64, 64)
             End If
         End If
-        frmMain.Coord.ForeColor = RGB(170, 0, 0)
+        Call frmMain.SetCoordColor(RGB(170, 0, 0))
     End If
     Exit Sub
 SwitchMap_Err:

--- a/CODIGO/frmMain.frm
+++ b/CODIGO/frmMain.frm
@@ -1248,10 +1248,178 @@ Begin VB.Form frmMain
       Top             =   990
       Width           =   465
    End
-   Begin VB.Label Coord 
+   Begin VB.Label CoordOutline1 
       Alignment       =   2  'Center
       AutoSize        =   -1  'True
       BackStyle       =   0  'Transparent
+      Caption         =   "000 X:00 Y: 00"
+      BeginProperty Font 
+         Name            =   "Calibri"
+         Size            =   9.75
+         Charset         =   0
+         Weight          =   700
+         Underline       =   0   'False
+         Italic          =   0   'False
+         Strikethrough   =   0   'False
+      EndProperty
+      ForeColor       =   &H00FFFFFF&
+      Height          =   225
+      Left            =   9705
+      TabIndex        =   14
+      Top             =   195
+      Width           =   1215
+   End
+   Begin VB.Label CoordOutline2 
+      Alignment       =   2  'Center
+      AutoSize        =   -1  'True
+      BackStyle       =   0  'Transparent
+      Caption         =   "000 X:00 Y: 00"
+      BeginProperty Font 
+         Name            =   "Calibri"
+         Size            =   9.75
+         Charset         =   0
+         Weight          =   700
+         Underline       =   0   'False
+         Italic          =   0   'False
+         Strikethrough   =   0   'False
+      EndProperty
+      ForeColor       =   &H00FFFFFF&
+      Height          =   225
+      Left            =   9720
+      TabIndex        =   14
+      Top             =   195
+      Width           =   1215
+   End
+   Begin VB.Label CoordOutline3 
+      Alignment       =   2  'Center
+      AutoSize        =   -1  'True
+      BackStyle       =   0  'Transparent
+      Caption         =   "000 X:00 Y: 00"
+      BeginProperty Font 
+         Name            =   "Calibri"
+         Size            =   9.75
+         Charset         =   0
+         Weight          =   700
+         Underline       =   0   'False
+         Italic          =   0   'False
+         Strikethrough   =   0   'False
+      EndProperty
+      ForeColor       =   &H00FFFFFF&
+      Height          =   225
+      Left            =   9735
+      TabIndex        =   14
+      Top             =   195
+      Width           =   1215
+   End
+   Begin VB.Label CoordOutline4 
+      Alignment       =   2  'Center
+      AutoSize        =   -1  'True
+      BackStyle       =   0  'Transparent
+      Caption         =   "000 X:00 Y: 00"
+      BeginProperty Font 
+         Name            =   "Calibri"
+         Size            =   9.75
+         Charset         =   0
+         Weight          =   700
+         Underline       =   0   'False
+         Italic          =   0   'False
+         Strikethrough   =   0   'False
+      EndProperty
+      ForeColor       =   &H00FFFFFF&
+      Height          =   225
+      Left            =   9705
+      TabIndex        =   14
+      Top             =   210
+      Width           =   1215
+   End
+   Begin VB.Label CoordOutline5 
+      Alignment       =   2  'Center
+      AutoSize        =   -1  'True
+      BackStyle       =   0  'Transparent
+      Caption         =   "000 X:00 Y: 00"
+      BeginProperty Font 
+         Name            =   "Calibri"
+         Size            =   9.75
+         Charset         =   0
+         Weight          =   700
+         Underline       =   0   'False
+         Italic          =   0   'False
+         Strikethrough   =   0   'False
+      EndProperty
+      ForeColor       =   &H00FFFFFF&
+      Height          =   225
+      Left            =   9735
+      TabIndex        =   14
+      Top             =   210
+      Width           =   1215
+   End
+   Begin VB.Label CoordOutline6 
+      Alignment       =   2  'Center
+      AutoSize        =   -1  'True
+      BackStyle       =   0  'Transparent
+      Caption         =   "000 X:00 Y: 00"
+      BeginProperty Font 
+         Name            =   "Calibri"
+         Size            =   9.75
+         Charset         =   0
+         Weight          =   700
+         Underline       =   0   'False
+         Italic          =   0   'False
+         Strikethrough   =   0   'False
+      EndProperty
+      ForeColor       =   &H00FFFFFF&
+      Height          =   225
+      Left            =   9705
+      TabIndex        =   14
+      Top             =   225
+      Width           =   1215
+   End
+   Begin VB.Label CoordOutline7 
+      Alignment       =   2  'Center
+      AutoSize        =   -1  'True
+      BackStyle       =   0  'Transparent
+      Caption         =   "000 X:00 Y: 00"
+      BeginProperty Font 
+         Name            =   "Calibri"
+         Size            =   9.75
+         Charset         =   0
+         Weight          =   700
+         Underline       =   0   'False
+         Italic          =   0   'False
+         Strikethrough   =   0   'False
+      EndProperty
+      ForeColor       =   &H00FFFFFF&
+      Height          =   225
+      Left            =   9720
+      TabIndex        =   14
+      Top             =   225
+      Width           =   1215
+   End
+   Begin VB.Label CoordOutline8 
+      Alignment       =   2  'Center
+      AutoSize        =   -1  'True
+      BackStyle       =   0  'Transparent
+      Caption         =   "000 X:00 Y: 00"
+      BeginProperty Font 
+         Name            =   "Calibri"
+         Size            =   9.75
+         Charset         =   0
+         Weight          =   700
+         Underline       =   0   'False
+         Italic          =   0   'False
+         Strikethrough   =   0   'False
+      EndProperty
+      ForeColor       =   &H00FFFFFF&
+      Height          =   225
+      Left            =   9735
+      TabIndex        =   14
+      Top             =   225
+      Width           =   1215
+   End
+   Begin VB.Label Coord 
+      Alignment       =   2  'Center
+      AutoSize        =   -1  'True
+      BackStyle        =   0  'Transparent
       Caption         =   "000 X:00 Y: 00"
       BeginProperty Font 
          Name            =   "Calibri"
@@ -3103,6 +3271,50 @@ Private Sub NameMapa_MouseMove(Button As Integer, Shift As Integer, x As Single,
     Exit Sub
 NameMapa_MouseMove_Err:
     Call RegistrarError(Err.Number, Err.Description, "frmMain.NameMapa_MouseMove", Erl)
+    Resume Next
+End Sub
+
+Public Sub SetCoordCaption(ByVal texto As String)
+    On Error GoTo SetCoordCaption_Err
+    CoordOutline1.Caption = texto
+    CoordOutline2.Caption = texto
+    CoordOutline3.Caption = texto
+    CoordOutline4.Caption = texto
+    CoordOutline5.Caption = texto
+    CoordOutline6.Caption = texto
+    CoordOutline7.Caption = texto
+    CoordOutline8.Caption = texto
+    Coord.Caption = texto
+    CoordOutline1.ZOrder 1
+    CoordOutline2.ZOrder 1
+    CoordOutline3.ZOrder 1
+    CoordOutline4.ZOrder 1
+    CoordOutline5.ZOrder 1
+    CoordOutline6.ZOrder 1
+    CoordOutline7.ZOrder 1
+    CoordOutline8.ZOrder 1
+    Coord.ZOrder 0
+    Exit Sub
+SetCoordCaption_Err:
+    Call RegistrarError(Err.Number, Err.Description, "frmMain.SetCoordCaption", Erl)
+    Resume Next
+End Sub
+
+Public Sub SetCoordColor(ByVal color As Long)
+    On Error GoTo SetCoordColor_Err
+    Coord.ForeColor = color
+    CoordOutline1.ForeColor = &H00FFFFFF&
+    CoordOutline2.ForeColor = &H00FFFFFF&
+    CoordOutline3.ForeColor = &H00FFFFFF&
+    CoordOutline4.ForeColor = &H00FFFFFF&
+    CoordOutline5.ForeColor = &H00FFFFFF&
+    CoordOutline6.ForeColor = &H00FFFFFF&
+    CoordOutline7.ForeColor = &H00FFFFFF&
+    CoordOutline8.ForeColor = &H00FFFFFF&
+    Coord.ZOrder 0
+    Exit Sub
+SetCoordColor_Err:
+    Call RegistrarError(Err.Number, Err.Description, "frmMain.SetCoordColor", Erl)
     Resume Next
 End Sub
 


### PR DESCRIPTION
Add SetCoordCaption and SetCoordColor helpers to frmMain and replace direct Coord label manipulation across the codebase. The form now includes eight CoordOutline labels to produce a white outline/shadow effect and z-order handling; SetCoordCaption updates all outline captions and Coord, while SetCoordColor sets Coord color and keeps outlines white. Updated call sites in ModGameplayUI.bas, Protocol.bas and TileEngine_Map.bas to use the new methods instead of directly setting Coord.Caption or Coord.ForeColor. Error handling/logging added to the new helpers.