### PR TITLE
Make chkAntiCheat a global switch, remove auto-toggling and dedupe repeated AntiCheat messages

### DIFF
--- a/CODIGO/frmPanelGm.frm
+++ b/CODIGO/frmPanelGm.frm
@@ -1981,25 +1981,6 @@ CerrarProceso_Click_Err:
 End Sub
 
 Private Sub chkAntiCheat_Click()
-    If chkAntiCheat.value = 0 Then
-        chkOcultar.value = False
-        chkUsarItem.value = False
-        chkLeftClick.value = False
-        chkPaquetes.value = False
-        chkCoordenadas.value = False
-        chkClicks.value = False
-        chkInasistido.value = False
-        chkCarteleo.value = False
-    Else
-        chkOcultar.value = 1
-        chkUsarItem.value = 1
-        chkLeftClick.value = 1
-        chkPaquetes.value = 1
-        chkCoordenadas.value = 1
-        chkClicks.value = 1
-        chkInasistido.value = 1
-        chkCarteleo.value = 1
-    End If
 End Sub
 
 Private Sub chkVerPanel_Click()
@@ -3240,6 +3221,19 @@ Public Sub CadenaChat(ByVal chat As String)
     Dim nombre        As String
     Dim nombreObjetivo As String
     Dim PosicionBarra As Integer
+    Static UltimaCadena As String
+    Static UltimoTiempo As Single
+    Dim TiempoActualCadena As Single
+
+    TiempoActualCadena = Timer
+
+    If chat = UltimaCadena Then
+        If TiempoActualCadena - UltimoTiempo < 3 Then Exit Sub
+    End If
+
+    UltimaCadena = chat
+    UltimoTiempo = TiempoActualCadena
+
     ' La cadena original
     Cadena = chat
     ' Divide la cadena en partes utilizando "Usuarios trabajando:" como separador
@@ -3257,8 +3251,9 @@ Public Sub CadenaChat(ByVal chat As String)
             cboListaUsus.AddItem Trim(Nombres(i))
         Next i
     End If
-    ' Divide la cadena en partes utilizando "Control de paquetes -> El usuario" como separador
-    partes = Split(Cadena, "Control Paquetes---> El usuario")
+    If chkAntiCheat.value = 1 Then
+        ' Divide la cadena en partes utilizando "Control de paquetes -> El usuario" como separador
+        partes = Split(Cadena, "Control Paquetes---> El usuario")
     ' Verifica si hay al menos dos partes en la matriz resultante
     If UBound(partes) >= 1 Then
         ' La segunda parte (índice 1) contiene el nombre y otros caracteres
@@ -3370,6 +3365,22 @@ Public Sub CadenaChat(ByVal chat As String)
         End If
     End If
 
+    Else
+        If InStr(Cadena, "Control Paquetes---> El usuario") > 0 Or InStr(Cadena, "Control de macro---> El usuario") > 0 Then
+            partes = Split(Cadena, "Control de macro---> El usuario")
+            If UBound(partes) >= 1 Then
+                nombre = partes(1)
+                PosicionBarra = InStr(nombre, "|")
+                If PosicionBarra > 0 Then
+                    nombre = Left(nombre, PosicionBarra - 1)
+                    nombre = Trim(nombre)
+                    If frmPanelgm.chkAutoName.value = 1 Then frmPanelgm.cboListaUsus.text = nombre
+                    If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(Cadena, "MacroTotal.txt")
+                End If
+            End If
+        End If
+    End If
+
     ' Captura avisos de hechizos para autocompletar el usuario atacante y/o objetivo
     If InStr(Cadena, "El usuario ") > 0 And InStr(Cadena, " esta lanzando hechizos al Usuario ") > 0 Then
         partes = Split(Cadena, "El usuario ")
@@ -3405,8 +3416,6 @@ Private Sub AplicarSancionMacro(ByVal nombre As String, ByVal cerrarCliente As B
         Call ParseUserCommand("/CARCEL " & nombre & "@Uso de programas externos, Macros o Cheat@" & tiempoCarcel)
     ElseIf cerrarCliente Then
         Call WriteCerraCliente(nombre)
-    Else
-        Call ParseUserCommand("/MENSAJEINFORMACION " & nombre & "@INFORMACION: Detectamos actividad sospechosa de macro. Esta accion fue registrada.")
     End If
 End Sub
 

--- a/CODIGO/frmPanelGm.frm
+++ b/CODIGO/frmPanelGm.frm
@@ -233,8 +233,8 @@ Begin VB.Form frmPanelgm
          Left            =   240
          TabIndex        =   106
          Text            =   "30"
-         Top             =   3120
-         Width           =   375
+         Top             =   3240
+         Width           =   495
       End
       Begin VB.CheckBox chkPaquetesCarcel 
          BackColor       =   &H80000007&
@@ -342,9 +342,9 @@ Begin VB.Form frmPanelgm
          Caption         =   "Min carcel"
          ForeColor       =   &H80000005&
          Height          =   195
-         Left            =   720
+         Left            =   840
          TabIndex        =   107
-         Top             =   3165
+         Top             =   3240
          Width           =   870
       End
       Begin VB.Label lblInasistido 
@@ -673,7 +673,6 @@ Begin VB.Form frmPanelgm
       Left            =   3240
       TabIndex        =   67
       Top             =   7680
-      Value           =   1  'Checked
       Width           =   255
    End
    Begin VB.CheckBox chkLeerInvisibleSi 
@@ -685,7 +684,7 @@ Begin VB.Form frmPanelgm
       TabIndex        =   108
       Top             =   7080
       Value           =   1  'Checked
-      Width           =   2175
+      Width           =   255
    End
    Begin VB.CheckBox chkLeerInvisibleNo 
       BackColor       =   &H00000000&
@@ -696,7 +695,7 @@ Begin VB.Form frmPanelgm
       TabIndex        =   109
       Top             =   7320
       Value           =   1  'Checked
-      Width           =   2175
+      Width           =   255
    End
    Begin VB.CommandButton cmdButtonActualizarListaGms 
       BackColor       =   &H80000018&
@@ -1261,6 +1260,26 @@ Begin VB.Form frmPanelgm
       TabIndex        =   7
       Top             =   600
       Width           =   4560
+   End
+   Begin VB.Label Label5 
+      BackColor       =   &H80000012&
+      Caption         =   "Leer visible"
+      ForeColor       =   &H00FFFFFF&
+      Height          =   255
+      Left            =   5160
+      TabIndex        =   111
+      Top             =   7320
+      Width           =   1335
+   End
+   Begin VB.Label Label4 
+      BackColor       =   &H80000012&
+      Caption         =   "Leer invisibles"
+      ForeColor       =   &H00FFFFFF&
+      Height          =   255
+      Left            =   5160
+      TabIndex        =   110
+      Top             =   7080
+      Width           =   1575
    End
    Begin VB.Label Label1 
       BackColor       =   &H00000000&

--- a/CODIGO/frmPanelGm.frm
+++ b/CODIGO/frmPanelGm.frm
@@ -3246,6 +3246,7 @@ Public Sub CadenaChat(ByVal chat As String)
     Static UltimaCadena As String
     Static UltimoTiempo As Single
     Dim TiempoActualCadena As Single
+    Dim macroTotalGuardado As Boolean
 
     TiempoActualCadena = Timer
 
@@ -3287,7 +3288,10 @@ Public Sub CadenaChat(ByVal chat As String)
             nombre = Left(nombre, PosicionBarra - 1)
             ' Elimina espacios en blanco al principio y al final del nombre
             nombre = Trim(nombre)
-            If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(Cadena, "MacroTotal.txt")
+            If chkInfoTXT.value = 1 And Not macroTotalGuardado Then
+                Resultado = GuardarTextoEnArchivo(Cadena, "MacroTotal.txt")
+                macroTotalGuardado = True
+            End If
             If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(Cadena, "MacroDePaquetes.txt")
             Call AplicarSancionMacro(nombre, frmPanelgm.chkPaquetes.value = 1, frmPanelgm.chkPaquetesCarcel.value = 1)
         End If
@@ -3345,7 +3349,10 @@ Public Sub CadenaChat(ByVal chat As String)
                     ' Manejar el caso en el que no hay coincidencias
             End Select
             If frmPanelgm.chkAutoName.value = 1 Then frmPanelgm.cboListaUsus.text = nombre
-            If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(Cadena, "MacroTotal.txt")
+            If chkInfoTXT.value = 1 And Not macroTotalGuardado Then
+                Resultado = GuardarTextoEnArchivo(Cadena, "MacroTotal.txt")
+                macroTotalGuardado = True
+            End If
         End If
     End If
     ' Divide la cadena en partes utilizando "AntiCheat> El usuario" como separador
@@ -3383,7 +3390,10 @@ Public Sub CadenaChat(ByVal chat As String)
                     ' Manejar el caso en el que no hay coincidencias
             End Select
             If frmPanelgm.chkAutoName.value = 1 Then frmPanelgm.cboListaUsus.text = nombre
-            If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(Cadena, "MacroTotal.txt")
+            If chkInfoTXT.value = 1 And Not macroTotalGuardado Then
+                Resultado = GuardarTextoEnArchivo(Cadena, "MacroTotal.txt")
+                macroTotalGuardado = True
+            End If
         End If
     End If
 
@@ -3397,7 +3407,10 @@ Public Sub CadenaChat(ByVal chat As String)
                     nombre = Left(nombre, PosicionBarra - 1)
                     nombre = Trim(nombre)
                     If frmPanelgm.chkAutoName.value = 1 Then frmPanelgm.cboListaUsus.text = nombre
-                    If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(Cadena, "MacroTotal.txt")
+                    If chkInfoTXT.value = 1 And Not macroTotalGuardado Then
+                Resultado = GuardarTextoEnArchivo(Cadena, "MacroTotal.txt")
+                macroTotalGuardado = True
+            End If
                 End If
             End If
         End If

--- a/CODIGO/frmPanelGm.frm
+++ b/CODIGO/frmPanelGm.frm
@@ -676,6 +676,28 @@ Begin VB.Form frmPanelgm
       Value           =   1  'Checked
       Width           =   255
    End
+   Begin VB.CheckBox chkLeerInvisibleSi 
+      BackColor       =   &H00000000&
+      Caption         =   "Leer Invisible SI"
+      ForeColor       =   &H80000005&
+      Height          =   255
+      Left            =   4800
+      TabIndex        =   66
+      Top             =   7080
+      Value           =   1  'Checked
+      Width           =   2175
+   End
+   Begin VB.CheckBox chkLeerInvisibleNo 
+      BackColor       =   &H00000000&
+      Caption         =   "Leer Invisible NO"
+      ForeColor       =   &H80000005&
+      Height          =   255
+      Left            =   4800
+      TabIndex        =   65
+      Top             =   7320
+      Value           =   1  'Checked
+      Width           =   2175
+   End
    Begin VB.CommandButton cmdButtonActualizarListaGms 
       BackColor       =   &H80000018&
       Caption         =   "Actualizar"
@@ -3218,6 +3240,9 @@ Public Sub CadenaChat(ByVal chat As String)
     Dim nombre        As String
     Dim nombreObjetivo As String
     Dim PosicionBarra As Integer
+    Dim cadenaMayus As String
+    Dim esInvisibleSi As Boolean
+    Dim esInvisibleNo As Boolean
     Static UltimaCadena As String
     Static UltimoTiempo As Single
     Dim TiempoActualCadena As Single
@@ -3379,6 +3404,13 @@ Public Sub CadenaChat(ByVal chat As String)
     End If
 
     ' Captura avisos de hechizos para autocompletar el usuario atacante y/o objetivo
+    cadenaMayus = UCase$(Cadena)
+    esInvisibleSi = (InStr(cadenaMayus, "INVISIBLE SI") > 0 Or InStr(cadenaMayus, "INVISIBILIDAD SI") > 0)
+    esInvisibleNo = (InStr(cadenaMayus, "INVISIBLE NO") > 0 Or InStr(cadenaMayus, "INVISIBILIDAD NO") > 0)
+
+    If esInvisibleSi And chkLeerInvisibleSi.value = 0 Then Exit Sub
+    If esInvisibleNo And chkLeerInvisibleNo.value = 0 Then Exit Sub
+
     If InStr(Cadena, "El usuario ") > 0 And InStr(Cadena, " esta lanzando hechizos al Usuario ") > 0 Then
         partes = Split(Cadena, "El usuario ")
         If UBound(partes) >= 1 Then

--- a/CODIGO/frmPanelGm.frm
+++ b/CODIGO/frmPanelGm.frm
@@ -6,7 +6,7 @@ Begin VB.Form frmPanelgm
    ClientHeight    =   8745
    ClientLeft      =   16095
    ClientTop       =   3480
-   ClientWidth     =   7155
+   ClientWidth     =   7170
    BeginProperty Font 
       Name            =   "Tahoma"
       Size            =   8.25
@@ -20,7 +20,7 @@ Begin VB.Form frmPanelgm
    MaxButton       =   0   'False
    MinButton       =   0   'False
    ScaleHeight     =   8745
-   ScaleWidth      =   7155
+   ScaleWidth      =   7170
    ShowInTaskbar   =   0   'False
    Begin VB.Frame MacrosCheat 
       BackColor       =   &H80000007&
@@ -682,7 +682,7 @@ Begin VB.Form frmPanelgm
       ForeColor       =   &H80000005&
       Height          =   255
       Left            =   4800
-      TabIndex        =   66
+      TabIndex        =   108
       Top             =   7080
       Value           =   1  'Checked
       Width           =   2175
@@ -693,7 +693,7 @@ Begin VB.Form frmPanelgm
       ForeColor       =   &H80000005&
       Height          =   255
       Left            =   4800
-      TabIndex        =   65
+      TabIndex        =   109
       Top             =   7320
       Value           =   1  'Checked
       Width           =   2175
@@ -774,7 +774,7 @@ Begin VB.Form frmPanelgm
       Left            =   4800
       Style           =   1  'Graphical
       TabIndex        =   45
-      Top             =   7080
+      Top             =   8040
       Width           =   2295
    End
    Begin VB.CommandButton cmdInseguro 

--- a/CODIGO/frmPanelGm.frm
+++ b/CODIGO/frmPanelGm.frm
@@ -1980,9 +1980,6 @@ CerrarProceso_Click_Err:
     Resume Next
 End Sub
 
-Private Sub chkAntiCheat_Click()
-End Sub
-
 Private Sub chkVerPanel_Click()
     If chkVerPanel.value = 1 Then
         FraControlMacros.visible = False

--- a/CODIGO/frmPanelGm.frm
+++ b/CODIGO/frmPanelGm.frm
@@ -679,7 +679,7 @@ Begin VB.Form frmPanelgm
    Begin VB.CheckBox chkLeerInvisibleSi 
       BackColor       =   &H00000000&
       Caption         =   "Leer Invisible SI"
-      ForeColor       =   &H80000005&
+      ForeColor       =   &H00FFFFFF&
       Height          =   255
       Left            =   4800
       TabIndex        =   108
@@ -690,7 +690,7 @@ Begin VB.Form frmPanelgm
    Begin VB.CheckBox chkLeerInvisibleNo 
       BackColor       =   &H00000000&
       Caption         =   "Leer Invisible NO"
-      ForeColor       =   &H80000005&
+      ForeColor       =   &H00FFFFFF&
       Height          =   255
       Left            =   4800
       TabIndex        =   109


### PR DESCRIPTION
### Motivation
- Prevent `chkAntiCheat` from automatically toggling other macro-related checkboxes so those remain fully manual and under operator control. 
- Ensure `chkAntiCheat` acts only as a global enable/disable for the AntiCheat sanctioning flow. 
- Avoid duplicate sanctions/logs/closures when the server re-sends the same AntiCheat message due to lag.

### Description
- Emptied `chkAntiCheat_Click` so it no longer marks/unmarks other checkboxes; manual controls remain unchanged (file: `CODIGO/frmPanelGm.frm`).
- Modified `Public Sub CadenaChat` to use `chkAntiCheat.Value` as the global switch: when `= 1` the existing detection/sanction/log flow is executed, and when `= 0` sanctions/close/jail actions are skipped while still performing `AutoName` updates and `MacroTotal.txt` logging as appropriate (file: `CODIGO/frmPanelGm.frm`).
- Added a short-term deduplication guard in `CadenaChat` using `Static UltimaCadena` + `Static UltimoTiempo` and a 3-second window to ignore repeated identical server messages to prevent double sanctions or logs (file: `CODIGO/frmPanelGm.frm`).
- Removed the final `/MENSAJEINFORMACION ... Detectamos actividad sospechosa...` call inside `AplicarSancionMacro` so the fallback `Else` no longer sends that message (file: `CODIGO/frmPanelGm.frm`).

### Testing
- Ran targeted source searches with `rg` to verify modified symbols (`chkAntiCheat_Click`, `CadenaChat`, `AplicarSancionMacro`) and confirm code locations; searches completed successfully. 
- Inspected the changes with `git diff -- CODIGO/frmPanelGm.frm` to validate the diff; diff reviewed and matches intended edits. 
- Committed the updated file with `git commit` to record the change; commit succeeded.
- No unit tests exist for this VB6 code in the repo, so verification was performed via static inspection of the modified file only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bd8a277f08328bc12dddff1bab2a7)