### PR TITLE
Fix: Crash en HandleCharAtaca cuando VictimIndex es 0

### DIFF
--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -3152,9 +3152,12 @@ Private Sub HandleCharAtaca()
         Exit Sub
     End If
 
-    If VictimIndex < LBound(charlist) Or VictimIndex > UBound(charlist) Then
-        Call RegistrarError(9, "VictimIndex fuera de rango: " & VictimIndex, "Protocol.HandleCharAtaca", Erl)
-        Exit Sub
+     ' VictimIndex puede ser 0 en ataques fallidos
+    If VictimIndex <> 0 Then
+        If VictimIndex < LBound(charlist) Or VictimIndex > UBound(charlist) Then
+            Call RegistrarError(9, "VictimIndex fuera de rango: " & VictimIndex, "Protocol.HandleCharAtaca", Erl)
+            Exit Sub
+        End If
     End If
 
     ' Si UserCharIndex puede ser 0/no seteado:
@@ -3258,10 +3261,12 @@ Private Sub HandleCharAtaca()
 
     End With
 
-    ' --- Guardrails: victim access ---
-    If danio > 0 Then
-        If charlist(VictimIndex).Navegando = 0 Then
-            Call SetCharacterFx(VictimIndex, 14, 0)
+  ' --- Guardrails: victim access ---
+    If danio > 0 And VictimIndex > 0 Then
+        If VictimIndex >= LBound(charlist) And VictimIndex <= UBound(charlist) Then
+            If charlist(VictimIndex).Navegando = 0 Then
+                Call SetCharacterFx(VictimIndex, 14, 0)
+            End If
         End If
     End If
 


### PR DESCRIPTION
## Problema
El protocolo lanzaba error 9 cuando VictimIndex era 0, causando crashes innecesarios en ataques fallidos o contra objetivos inválidos.

## Causa
El guardrail validaba VictimIndex sin considerar que 0 es un valor válido del servidor (representa "sin víctima" en ataques fallidos).

## Solución
- Permitir VictimIndex = 0 sin loguear error
- Validar rango solo cuando VictimIndex > 0
- Aplicar daño/efectos únicamente si VictimIndex está en rango válido

## Cambios
- Actualizado guardrail de VictimIndex en lectura de protocolo
- Agregada validación adicional antes de SetCharacterFx()

## Testing
- Verificado con Heading enum (1-4)
- Ataques fallidos ya no generan excepciones