### PR TITLE
Evita registros duplicados en MacroTotal.txt al procesar macros

### DIFF
--- a/CODIGO/frmPanelGm.frm
+++ b/CODIGO/frmPanelGm.frm
@@ -3246,6 +3246,7 @@ Public Sub CadenaChat(ByVal chat As String)
     Static UltimaCadena As String
     Static UltimoTiempo As Single
     Dim TiempoActualCadena As Single
+    Dim macroTotalGuardado As Boolean
 
     TiempoActualCadena = Timer
 
@@ -3287,7 +3288,10 @@ Public Sub CadenaChat(ByVal chat As String)
             nombre = Left(nombre, PosicionBarra - 1)
             ' Elimina espacios en blanco al principio y al final del nombre
             nombre = Trim(nombre)
-            If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(Cadena, "MacroTotal.txt")
+            If chkInfoTXT.value = 1 And Not macroTotalGuardado Then
+                Resultado = GuardarTextoEnArchivo(Cadena, "MacroTotal.txt")
+                macroTotalGuardado = True
+            End If
             If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(Cadena, "MacroDePaquetes.txt")
             Call AplicarSancionMacro(nombre, frmPanelgm.chkPaquetes.value = 1, frmPanelgm.chkPaquetesCarcel.value = 1)
         End If
@@ -3345,7 +3349,10 @@ Public Sub CadenaChat(ByVal chat As String)
                     ' Manejar el caso en el que no hay coincidencias
             End Select
             If frmPanelgm.chkAutoName.value = 1 Then frmPanelgm.cboListaUsus.text = nombre
-            If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(Cadena, "MacroTotal.txt")
+            If chkInfoTXT.value = 1 And Not macroTotalGuardado Then
+                Resultado = GuardarTextoEnArchivo(Cadena, "MacroTotal.txt")
+                macroTotalGuardado = True
+            End If
         End If
     End If
     ' Divide la cadena en partes utilizando "AntiCheat> El usuario" como separador
@@ -3383,7 +3390,10 @@ Public Sub CadenaChat(ByVal chat As String)
                     ' Manejar el caso en el que no hay coincidencias
             End Select
             If frmPanelgm.chkAutoName.value = 1 Then frmPanelgm.cboListaUsus.text = nombre
-            If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(Cadena, "MacroTotal.txt")
+            If chkInfoTXT.value = 1 And Not macroTotalGuardado Then
+                Resultado = GuardarTextoEnArchivo(Cadena, "MacroTotal.txt")
+                macroTotalGuardado = True
+            End If
         End If
     End If
 
@@ -3397,7 +3407,10 @@ Public Sub CadenaChat(ByVal chat As String)
                     nombre = Left(nombre, PosicionBarra - 1)
                     nombre = Trim(nombre)
                     If frmPanelgm.chkAutoName.value = 1 Then frmPanelgm.cboListaUsus.text = nombre
-                    If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(Cadena, "MacroTotal.txt")
+                    If chkInfoTXT.value = 1 And Not macroTotalGuardado Then
+                Resultado = GuardarTextoEnArchivo(Cadena, "MacroTotal.txt")
+                macroTotalGuardado = True
+            End If
                 End If
             End If
         End If


### PR DESCRIPTION
### Motivation
- Evitar que la misma entrada de chat se escriba varias veces en `MacroTotal.txt` cuando el mensaje entra en múltiples ramas de detección de macro dentro de `CadenaChat`.

### Description
- Se añadió una bandera local `macroTotalGuardado` en `CadenaChat` para marcar si ya se guardó la cadena en `MacroTotal.txt` durante el procesamiento de ese mensaje.
- Se reemplazaron las escrituras directas a `MacroTotal.txt` por comprobaciones `If chkInfoTXT.value = 1 And Not macroTotalGuardado Then` y se establece `macroTotalGuardado = True` tras la primera escritura.
- Se aplicó la protección en todos los puntos del método que previamente llamaban `GuardarTextoEnArchivo(..., "MacroTotal.txt")`, incluyendo las rutas de `Control Paquetes`, `Control de macro` y el bloque alternativo final.

### Testing
- Se verificó la presencia y ubicación de la bandera con `rg -n "macroTotalGuardado|MacroTotal.txt" CODIGO/frmPanelGm.frm` y produjo los resultados esperados (éxito).
- Se inspeccionó el bloque modificado con `sed -n '3238,3410p' CODIGO/frmPanelGm.frm` y `nl -ba CODIGO/frmPanelGm.frm | sed -n '3238,3420p'` para confirmar las inserciones (éxito).
- Se comprobó búsqueda de patrones relacionados con macros con `rg -n "Control de macro|macro total|macrototal|Envíos" .` (éxito).
- Se registró el cambio en el repositorio con `git add` y `git commit` (commit creado correctamente).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4f14f5448328bee7eab719c70fe9)