### PR TITLE
Usar WriteCancelarEvento para las acciones de cancelar

### DIFF
--- a/CODIGO/FrmTorneo.frm
+++ b/CODIGO/FrmTorneo.frm
@@ -1339,9 +1339,7 @@ Private Sub cmdCancelarDeath_Click()
 End Sub
 
 Private Sub cmdCancelarTodos_Click()
-    Call WriteCancelarTorneo
-    Call ParseUserCommand("/configlobby end")
-    Call ParseUserCommand("/cancelarevento")
+    Call WriteCancelarEvento
 End Sub
 
 Private Sub cmdCancelarTorneo_Click()
@@ -1462,6 +1460,7 @@ Private Sub Command3_Click()
 End Sub
 
 Private Sub Command5_Click()
+    Call WriteCancelarEvento
     FrmTorneo.FraCapturaDe.visible = False
     FrmTorneo.FraTorneosY.visible = True
 End Sub

--- a/CODIGO/frmPanelGm.frm
+++ b/CODIGO/frmPanelGm.frm
@@ -3093,8 +3093,7 @@ End Sub
 
 Private Sub torneo_cancelar_Click()
     On Error GoTo torneo_cancelar_Click_Err
-    Call WriteCancelarTorneo
-    Call ParseUserCommand("/configlobby end")
+    Call WriteCancelarEvento
     Exit Sub
 torneo_cancelar_Click_Err:
     Call RegistrarError(Err.Number, Err.Description, "frmPanelGM.torneo_cancelar_Click", Erl)


### PR DESCRIPTION
Reemplazar las llamadas directas a WriteCancelarTorneo/ParseUserCommand por un único Call WriteCancelarEvento para unificar el comportamiento de cancelación. Cambios aplicados en FrmTorneo (cmdCancelarTodos_Click, Command5_Click) y frmPanelGm (torneo_cancelar_Click).