### PR TITLE
Ajusta el grosor del borde blanco en las coordenadas de frmMain

### DIFF
--- a/CODIGO/frmMain.frm
+++ b/CODIGO/frmMain.frm
@@ -3303,14 +3303,14 @@ End Sub
 Public Sub SetCoordColor(ByVal color As Long)
     On Error GoTo SetCoordColor_Err
     Coord.ForeColor = color
-    CoordOutline1.ForeColor = &H00FFFFFF&
-    CoordOutline2.ForeColor = &H00FFFFFF&
-    CoordOutline3.ForeColor = &H00FFFFFF&
-    CoordOutline4.ForeColor = &H00FFFFFF&
-    CoordOutline5.ForeColor = color
-    CoordOutline6.ForeColor = color
-    CoordOutline7.ForeColor = color
-    CoordOutline8.ForeColor = color
+    CoordOutline1.ForeColor = RGB(20, 20, 20)
+    CoordOutline2.ForeColor = RGB(20, 20, 20)
+    CoordOutline3.ForeColor = RGB(20, 20, 20)
+    CoordOutline4.ForeColor = RGB(20, 20, 20)
+    CoordOutline5.ForeColor = RGB(20, 20, 20)
+    CoordOutline6.ForeColor = RGB(20, 20, 20)
+    CoordOutline7.ForeColor = RGB(20, 20, 20)
+    CoordOutline8.ForeColor = RGB(20, 20, 20)
     Coord.ZOrder 0
     Exit Sub
 SetCoordColor_Err:

--- a/CODIGO/frmMain.frm
+++ b/CODIGO/frmMain.frm
@@ -3280,10 +3280,10 @@ Public Sub SetCoordCaption(ByVal texto As String)
     CoordOutline2.Caption = texto
     CoordOutline3.Caption = texto
     CoordOutline4.Caption = texto
-    CoordOutline5.Caption = texto
-    CoordOutline6.Caption = texto
-    CoordOutline7.Caption = texto
-    CoordOutline8.Caption = texto
+    CoordOutline5.Caption = vbNullString
+    CoordOutline6.Caption = vbNullString
+    CoordOutline7.Caption = vbNullString
+    CoordOutline8.Caption = vbNullString
     Coord.Caption = texto
     CoordOutline1.ZOrder 1
     CoordOutline2.ZOrder 1
@@ -3307,10 +3307,10 @@ Public Sub SetCoordColor(ByVal color As Long)
     CoordOutline2.ForeColor = &H00FFFFFF&
     CoordOutline3.ForeColor = &H00FFFFFF&
     CoordOutline4.ForeColor = &H00FFFFFF&
-    CoordOutline5.ForeColor = &H00FFFFFF&
-    CoordOutline6.ForeColor = &H00FFFFFF&
-    CoordOutline7.ForeColor = &H00FFFFFF&
-    CoordOutline8.ForeColor = &H00FFFFFF&
+    CoordOutline5.ForeColor = color
+    CoordOutline6.ForeColor = color
+    CoordOutline7.ForeColor = color
+    CoordOutline8.ForeColor = color
     Coord.ZOrder 0
     Exit Sub
 SetCoordColor_Err:


### PR DESCRIPTION
## Resumen
- Reduje el efecto de contorno blanco en el texto de coordenadas mostrado en `frmMain`.
- Se mantiene el texto principal y un borde más sutil para mejorar legibilidad sin que se vea tan marcado.

## Cambios realizados
- En `CODIGO/frmMain.frm` (`SetCoordCaption`):
  - `CoordOutline5` a `CoordOutline8` ahora se limpian (`vbNullString`) para no renderizar las capas adicionales del contorno.
- En `CODIGO/frmMain.frm` (`SetCoordColor`):
  - `CoordOutline5` a `CoordOutline8` dejaron de usar blanco y pasan a usar el color principal, evitando que aporten grosor al borde blanco.

## Impacto
- El borde blanco queda visiblemente más fino y menos invasivo.
- No cambia la lógica de actualización de coordenadas ni su color principal dinámico.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e0e39d6408324be3ff891066fabfe)