### PR TITLE
Apply PanelGM invisible-message filters to main console output

### DIFF
--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -1945,6 +1945,10 @@ Private Sub HandleConsoleMessage()
             extra = ReadField(3, chat, Asc("*"))
             chat = Locale_Parse_ServerMessage(id, extra)
     End Select
+    If EsGM Then
+        If Not frmPanelgm.DebeMostrarMensaje(chat) Then Exit Sub
+    End If
+
     If InStr(1, chat, "~") Then
         str = ReadField(2, chat, 126)
         If val(str) > 255 Then

--- a/CODIGO/frmPanelGm.frm
+++ b/CODIGO/frmPanelGm.frm
@@ -3252,15 +3252,30 @@ Private Sub mnuConsulta_Click()
     End If
 End Sub
 
+
+Public Function DebeMostrarMensaje(ByVal Cadena As String) As Boolean
+    Dim cadenaMayus As String
+
+    DebeMostrarMensaje = True
+
+    cadenaMayus = UCase$(Cadena)
+
+    If (InStr(cadenaMayus, "INVISIBLE SI") > 0 Or InStr(cadenaMayus, "INVISIBILIDAD SI") > 0) Then
+        If chkLeerInvisibleSi.value = 0 Then DebeMostrarMensaje = False
+        Exit Function
+    End If
+
+    If (InStr(cadenaMayus, "INVISIBLE NO") > 0 Or InStr(cadenaMayus, "INVISIBILIDAD NO") > 0) Then
+        If chkLeerInvisibleNo.value = 0 Then DebeMostrarMensaje = False
+    End If
+End Function
+
 Public Sub CadenaChat(ByVal chat As String)
     Dim Cadena        As String
     Dim partes()      As String
     Dim nombre        As String
     Dim nombreObjetivo As String
     Dim PosicionBarra As Integer
-    Dim cadenaMayus As String
-    Dim esInvisibleSi As Boolean
-    Dim esInvisibleNo As Boolean
     Static UltimaCadena As String
     Static UltimoTiempo As Single
     Dim TiempoActualCadena As Single
@@ -3435,12 +3450,7 @@ Public Sub CadenaChat(ByVal chat As String)
     End If
 
     ' Captura avisos de hechizos para autocompletar el usuario atacante y/o objetivo
-    cadenaMayus = UCase$(Cadena)
-    esInvisibleSi = (InStr(cadenaMayus, "INVISIBLE SI") > 0 Or InStr(cadenaMayus, "INVISIBILIDAD SI") > 0)
-    esInvisibleNo = (InStr(cadenaMayus, "INVISIBLE NO") > 0 Or InStr(cadenaMayus, "INVISIBILIDAD NO") > 0)
-
-    If esInvisibleSi And chkLeerInvisibleSi.value = 0 Then Exit Sub
-    If esInvisibleNo And chkLeerInvisibleNo.value = 0 Then Exit Sub
+    If Not DebeMostrarMensaje(Cadena) Then Exit Sub
 
     If InStr(Cadena, "El usuario ") > 0 And InStr(Cadena, " esta lanzando hechizos al Usuario ") > 0 Then
         partes = Split(Cadena, "El usuario ")


### PR DESCRIPTION
### Motivation
- Fix a bug where GM panel checkboxes (`chkLeerInvisibleSi`/`chkLeerInvisibleNo`) only prevented processing inside the GM panel but did not stop those lines from being printed to the main console. 
- Centralize the invisible-message filter so the same rule is used both for panel parsing and for deciding whether to show a line in the console.

### Description
- Added a new helper `Public Function DebeMostrarMensaje(ByVal Cadena As String) As Boolean` to `CODIGO/frmPanelGm.frm` to evaluate `INVISIBLE SI/NO` and `INVISIBILIDAD SI/NO` against the two checkboxes. 
- Replaced duplicated invisible-message checks in `frmPanelgm.CadenaChat` with a call to `DebeMostrarMensaje(Cadena)`. 
- Updated `CODIGO/Protocol.bas` (`HandleConsoleMessage`) to call `If Not frmPanelgm.DebeMostrarMensaje(chat) Then Exit Sub` when `EsGM` is true, so filtered messages are not written to the main console before `AddtoRichTextBox`.

### Testing
- Verified the changes with `git diff -- CODIGO/frmPanelGm.frm CODIGO/Protocol.bas` to confirm the new function and the `HandleConsoleMessage` early-exit were added, and this check succeeded. 
- Inspected the patched files with `nl -ba ... | sed -n` and `sed -n` to validate the inserted function and the updated calls, and these inspections succeeded. 
- Committed the changes (`git commit`) to the local repo; no unit/automated test suite was available for the VB6 project so no runtime/unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16f78cce40832881afb54427f6652a)