### PR TITLE
Validate magic cast target against actual cursor tile and log suspicious macro clicks

### DIFF
--- a/CODIGO/ModGameplayUI.bas
+++ b/CODIGO/ModGameplayUI.bas
@@ -220,10 +220,13 @@ Public Sub OnClick(ByVal MouseButton As Long, ByVal MouseShift As Long)
                     End If
                     If SendSkill Then
                         If UsingSkill = eSkill.magia Then
-                            If ComprobarPosibleMacro(mouseX, mouseY) Then
-                                Call WriteWorkLeftClick(tX + RandomNumber(-2, 2), tY + RandomNumber(-2, 2), UsingSkill)
-                            Else
-                                Call WriteWorkLeftClick(tX, tY, UsingSkill)
+                            ' Bloquea el envio si el tile objetivo no coincide con la posicion real del cursor.
+                            If CoincideObjetivoHechizoConMouse(tX, tY) Then
+                                If ComprobarPosibleMacro(mouseX, mouseY) Then
+                                    Call WriteWorkLeftClick(tX + RandomNumber(-2, 2), tY + RandomNumber(-2, 2), UsingSkill)
+                                Else
+                                    Call WriteWorkLeftClick(tX, tY, UsingSkill)
+                                End If
                             End If
                         Else
                             Call WriteWorkLeftClick(tX, tY, UsingSkill)

--- a/CODIGO/ModTaehcitna.bas
+++ b/CODIGO/ModTaehcitna.bas
@@ -17,7 +17,10 @@ Attribute VB_Name = "ModTaehcitna"
 '
 Option Explicit
 Private Const MAX_COMPROBACIONES As Byte = 4
+' Obtiene una muestra independiente del cursor desde Windows para no confiar en coordenadas cacheadas.
 Private Declare Function GetCursorPos Lib "user32" (lpPoint As POINTAPI) As Long
+' Convierte la muestra global de Windows a coordenadas locales del control de render.
+Private Declare Function ScreenToClient Lib "user32" (ByVal hWnd As Long, lpPoint As POINTAPI) As Long
 Private ContadorMacroClicks(1 To MAX_COMPROBACIONES) As Position
 Public LastSentPosX                                  As Integer
 Public LastSentPosY                                  As Integer
@@ -38,15 +41,21 @@ Public Function ComprobarPosibleMacro(ByVal mouseX As Integer, ByVal mouseY As I
 End Function
 
 Public Function CoincideObjetivoHechizoConMouse(ByVal objetivoX As Byte, ByVal objetivoY As Byte) As Boolean
-    ' Recalcula el tile del cursor al confirmar el hechizo para no depender del ultimo frame renderizado.
+    ' Toma la posicion real del cursor desde Windows para no confiar en valores modificables del cliente.
+    Dim cursorReal As POINTAPI
     Dim mouseTileX As Byte
     Dim mouseTileY As Byte
 
-    ' Rechaza acciones dirigidas cuando el cursor real no se encuentra dentro del render.
-    If mouseX < 0 Or mouseX > frmMain.renderer.ScaleWidth Then Exit Function
-    If mouseY < 0 Or mouseY > frmMain.renderer.ScaleHeight Then Exit Function
+    ' Rechaza el envio si Windows no puede informar o convertir la posicion actual del cursor.
+    If GetCursorPos(cursorReal) = 0 Then Exit Function
+    If ScreenToClient(frmMain.renderer.hWnd, cursorReal) = 0 Then Exit Function
 
-    Call ConvertCPtoTP(mouseX, mouseY, mouseTileX, mouseTileY)
+    ' Rechaza acciones dirigidas cuando el cursor real no se encuentra dentro del render.
+    If cursorReal.x < 0 Or cursorReal.x > frmMain.renderer.ScaleWidth Then Exit Function
+    If cursorReal.y < 0 Or cursorReal.y > frmMain.renderer.ScaleHeight Then Exit Function
+
+    ' Convierte exclusivamente la muestra independiente del cursor al tile real señalado.
+    Call ConvertCPtoTP(cursorReal.x, cursorReal.y, mouseTileX, mouseTileY)
 
     ' Solo permite enviar el hechizo cuando su objetivo coincide con el tile real del cursor.
     CoincideObjetivoHechizoConMouse = (mouseTileX = objetivoX And mouseTileY = objetivoY)

--- a/CODIGO/ModTaehcitna.bas
+++ b/CODIGO/ModTaehcitna.bas
@@ -37,6 +37,24 @@ Public Function ComprobarPosibleMacro(ByVal mouseX As Integer, ByVal mouseY As I
     Call generarLogMacrero
 End Function
 
+Public Function CoincideObjetivoHechizoConMouse(ByVal objetivoX As Byte, ByVal objetivoY As Byte) As Boolean
+    ' Recalcula el tile del cursor al confirmar el hechizo para no depender del ultimo frame renderizado.
+    Dim mouseTileX As Byte
+    Dim mouseTileY As Byte
+
+    ' Rechaza acciones dirigidas cuando el cursor real no se encuentra dentro del render.
+    If mouseX < 0 Or mouseX > frmMain.renderer.ScaleWidth Then Exit Function
+    If mouseY < 0 Or mouseY > frmMain.renderer.ScaleHeight Then Exit Function
+
+    Call ConvertCPtoTP(mouseX, mouseY, mouseTileX, mouseTileY)
+
+    ' Solo permite enviar el hechizo cuando su objetivo coincide con el tile real del cursor.
+    CoincideObjetivoHechizoConMouse = (mouseTileX = objetivoX And mouseTileY = objetivoY)
+
+    ' Informa al servidor la diferencia de coordenadas para que pueda registrar el intento sospechoso.
+    If Not CoincideObjetivoHechizoConMouse Then Call WriteLogMacroClickHechizo(tMacro.Coordenadas)
+End Function
+
 Private Sub generarLogMacrero()
     Call WriteLogMacroClickHechizo(tMacro.inasistidoPosFija)
 End Sub

--- a/CODIGO/frmMain.frm
+++ b/CODIGO/frmMain.frm
@@ -3608,6 +3608,10 @@ End Sub
 
 Private Sub renderer_MouseDown(Button As Integer, Shift As Integer, x As Single, y As Single)
     On Error GoTo renderer_MouseDown_Err
+    ' Sincroniza el tile objetivo con la posicion exacta del cursor al comenzar el click dentro del render.
+    mouseX = x
+    mouseY = y
+    Call ConvertCPtoTP(mouseX, mouseY, tX, tY)
     If SendTxt.visible Then SendTxt.SetFocus
     MouseBoton = Button
     MouseShift = Shift


### PR DESCRIPTION
### Motivation
- Prevent sending magic-cast actions when the confirmed target tile does not match the real cursor tile to reduce false/automated actions. 
- Reduce effectiveness of simple macro/click spoofing by re-checking the cursor tile on click confirmation. 
- Provide server-side telemetry by logging mismatched attempts for further analysis.

### Description
- Added `CoincideObjetivoHechizoConMouse` in `ModTaehcitna.bas` to recompute the cursor tile from screen coordinates, enforce render-bound checks, compare against the intended target, and call `WriteLogMacroClickHechizo` when they differ. 
- Modified `OnClick` in `ModGameplayUI.bas` to call `CoincideObjetivoHechizoConMouse` before sending a magic skill (`eSkill.magia`) and only transmit the action when the target matches the real cursor tile, while preserving existing macro-randomization behavior. 
- Synchronized global `mouseX`/`mouseY` and converted to tile coordinates in `renderer_MouseDown` inside `frmMain.frm` by setting `mouseX = x`, `mouseY = y` and calling `ConvertCPtoTP` to ensure the confirmed click uses an up-to-date cursor position.

### Testing
- Performed an automated project build/compile which completed successfully. 
- Executed the repository's existing automated test suite where available and observed all tests passing. 
- No automated tests failed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d599972408328bd01f4ad299a4cfd)