### PR TITLE
Remove obsolete REMOTE_CLOSE client support

### DIFF
--- a/CODIGO/Declares.bas
+++ b/CODIGO/Declares.bas
@@ -508,7 +508,6 @@ Public TransferCharname     As String
 Public TransferCharNewOwner As String
 Public CuentaPassword       As String
 Public CuentaEmail          As String
-Public CharacterRemote      As String
 Public NamePj(1 To 8)       As String
 Public ValidationCode       As String
 'Objetos públicos
@@ -1111,10 +1110,6 @@ Public IPdelServidor          As String
 Public PuertoDelServidor      As String
 Public IPdelServidorLogin     As String
 Public PuertoDelServidorLogin As String
-#If REMOTE_CLOSE = 1 Then
-    Public InitiateShutdownProcess As Boolean
-    Public ShutdownProcessTimer    As New clsInstrument
-#End If
 '
 '********** FUNCIONES API ***********
 '

--- a/CODIGO/General.bas
+++ b/CODIGO/General.bas
@@ -731,47 +731,6 @@ Public Sub SaveStringInFile(ByVal Cadena As String, ByVal nombreArchivo As Strin
 ErrorHandler:
 End Sub
 
-Sub parse_cmd_line_args()
-    #If REMOTE_CLOSE = 1 Then
-        Call Application.DeleteFile("remote_debug.txt")
-        IPdelServidorLogin = "127.0.0.1"
-        PuertoDelServidorLogin = 4000
-        IPdelServidor = IPdelServidorLogin
-        PuertoDelServidor = 6501
-        CuentaEmail = "some@yahoo.com.ar"
-        CuentaPassword = "secret"
-        CharacterRemote = "rolo"
-        Dim sArgs() As String
-        Dim iLoop   As Integer
-        sArgs = Split(command$, " ")
-        For iLoop = 0 To UBound(sArgs)
-            frmDebug.add_text_tracebox sArgs(iLoop)
-            Dim value() As String
-            value = Split(sArgs(iLoop), "=")
-            If value(0) = "account" Then
-                CuentaEmail = value(1)
-            ElseIf value(0) = "password" Then
-                CuentaPassword = value(1)
-            ElseIf value(0) = "serverip" Then
-                IPdelServidorLogin = value(1)
-                IPdelServidor = value(1)
-            ElseIf value(0) = "lport" Then
-                PuertoDelServidorLogin = value(1)
-            ElseIf value(0) = "gport" Then
-                PuertoDelServidor = value(1)
-            ElseIf value(0) = "pc" Then
-                CharacterRemote = value(1)
-            End If
-        Next
-        Call SaveStringInFile("Using IPdelServidorLogin: " & IPdelServidorLogin, "remote_debug.txt")
-        Call SaveStringInFile("Using PuertoDelServidorLogin: " & PuertoDelServidorLogin, "remote_debug.txt")
-        Call SaveStringInFile("Using IPdelServidor: " & IPdelServidor, "remote_debug.txt")
-        Call SaveStringInFile("Using PuertoDelServidor: " & PuertoDelServidor, "remote_debug.txt")
-        Call SaveStringInFile("Using CuentaEmail: " & CuentaEmail, "remote_debug.txt")
-        Call SaveStringInFile("Using CuentaPassword: " & CuentaPassword, "remote_debug.txt")
-        Call SaveStringInFile("Using CharacterRemote: " & CharacterRemote, "remote_debug.txt")
-    #End If
-End Sub
 
 Sub Main()
     On Error GoTo Main_Err
@@ -793,17 +752,10 @@ UnitTest_Err:
     debug_tools.Init
     frmDebug.add_text_tracebox debug_tools.BuildFlags
     
-    Call parse_cmd_line_args
     'Must be at the top to make sure te resources password is loaded before we attempt to load anything
     'TODO: Remove the PASSWORD, it's useless and slow and remove the call to DoCrypt_Data bytArr, Passwd
     'Moving forward use only dycryptosys API Decompress_Data_B bytArr, InfoHead.lngFileSizeUncompressed
     Call CheckResources
-    #If REMOTE_CLOSE Then
-        Call Recursos.LoadFonts
-        Call DoLogin("", "", False)
-        Call bot_main_loop
-        End
-    #End If
     Call Application.DeleteFile(ao20config.GetErrorLogFilename())
     Call LoadConfig
     Call SetLanguageApplication

--- a/CODIGO/ModAuth.bas
+++ b/CODIGO/ModAuth.bas
@@ -862,9 +862,7 @@ Public Sub connectToLoginServer()
     frmConnect.AuthSocket.RemotePort = PuertoDelServidorLogin
     frmDebug.add_text_tracebox "Servidor de Login " & IPdelServidorLogin & ":" & PuertoDelServidorLogin
     frmConnect.AuthSocket.Connect
-    #If REMOTE_CLOSE = 0 Then
-        Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_CONECTANDO_SERVIDOR"), True, False)
-    #End If
+    Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_CONECTANDO_SERVIDOR"), True, False)
     SessionOpened = False
     Auth_state = e_state.Idle
 End Sub
@@ -906,14 +904,9 @@ Public Sub HandlePCList(ByVal BytesTotal As Long)
     frmConnect.AuthSocket.GetData encrypted_list, packet_size - 4
     Dim decrypted_list As String
     decrypted_list = AO20CryptoSysWrapper.Decrypt(ByteArrayToHex(public_key), cnvStringFromHexStr(cnvToHex(encrypted_list)))
-    #If REMOTE_CLOSE = 0 Then
-        Call FillAccountData(decrypted_list)
-    #End If
+    Call FillAccountData(decrypted_list)
     Call DebugPrint("Decrypted_list: " & decrypted_list, 255, 255, 255, False)
     Auth_state = e_state.AccountLogged
-    #If REMOTE_CLOSE = 1 Then
-        LoginCharacter (CharacterRemote)
-    #End If
 End Sub
 
 Public Sub HandleAccountLogin(ByVal BytesTotal As Long)
@@ -932,51 +925,28 @@ Public Sub HandleAccountLogin(ByVal BytesTotal As Long)
     Else
         frmDebug.add_text_tracebox "LOGIN-ERROR"
         frmConnect.AuthSocket.GetData data, vbByte, 4
-        #If REMOTE_CLOSE = 0 Then
-            Select Case MakeInt(data(3), data(2))
-                Case 1
-                    Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_USUARIO_INVALIDO"), False, False)
-                Case 4
-                    Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_USUARIO_CONECTADO"), False, False)
-                    If Not FullLogout Then
-                        Call SendAccountLoginRequest
-                    End If
-                Case 5
-                    Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_CONTRASENA_INVALIDA"), False, False)
-                Case 6
-                    Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_USUARIO_BANEADO"), False, False)
-                Case 7
-                    Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_SERVIDOR_MAX_USUARIOS"), False, False)
-                Case 9
-                    Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_CUENTA_NO_ACTIVADA"), False, False)
-                Case 66
-                    Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_ACTIVO_PATRON"), False, False)
-                Case Else
-                    Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_ACTUALIZAR_JUEGO"), False, False)
-            End Select
-        End If
-    #Else
         Select Case MakeInt(data(3), data(2))
             Case 1
-                Call SaveStringInFile("MENSAJEBOX_USUARIO_INVALIDO", "remote_debug.txt")
+                Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_USUARIO_INVALIDO"), False, False)
             Case 4
-                Call SaveStringInFile("MENSAJEBOX_USUARIO_CONECTADO", "remote_debug.txt")
+                Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_USUARIO_CONECTADO"), False, False)
+                If Not FullLogout Then
+                    Call SendAccountLoginRequest
+                End If
             Case 5
-                Call SaveStringInFile("MENSAJEBOX_CONTRASENA_INVALIDA", "remote_debug.txt")
+                Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_CONTRASENA_INVALIDA"), False, False)
             Case 6
-                Call SaveStringInFile("MENSAJEBOX_USUARIO_BANEADO", "remote_debug.txt")
+                Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_USUARIO_BANEADO"), False, False)
             Case 7
-                Call SaveStringInFile("MENSAJEBOX_SERVIDOR_MAX_USUARIOS", "remote_debug.txt")
+                Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_SERVIDOR_MAX_USUARIOS"), False, False)
             Case 9
-                Call SaveStringInFile("MENSAJEBOX_CUENTA_NO_ACTIVADA", "remote_debug.txt")
+                Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_CUENTA_NO_ACTIVADA"), False, False)
             Case 66
-                Call SaveStringInFile("MENSAJEBOX_ACTIVO_PATRON", "remote_debug.txt")
+                Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_ACTIVO_PATRON"), False, False)
             Case Else
-                Call SaveStringInFile("MENSAJEBOX_ACTUALIZAR_JUEGO", "remote_debug.txt")
+                Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_ACTUALIZAR_JUEGO"), False, False)
         End Select
-        prgRun = False
     End If
-#End If
 End Sub
 
 Public Sub GotoPasswordReset()

--- a/CODIGO/ModLogin.bas
+++ b/CODIGO/ModLogin.bas
@@ -42,27 +42,22 @@ Public CurrentLoginServerIndex As Integer
    
 Public Sub DoLogin(ByVal Account As String, ByVal Password As String, ByVal storeCredentials As Boolean)
     On Error GoTo DoLogin_Err
-    #If REMOTE_CLOSE = 1 Then
-        ModAuth.LoginOperation = e_operation.Authenticate
-        Call LoginOrConnect(E_MODO.IngresandoConCuenta)
-    #Else
-        If IntervaloPermiteConectar Then
-            CuentaEmail = Account
-            CuentaPassword = Password
-            If storeCredentials Then
-                CuentaRecordada.nombre = CuentaEmail
-                CuentaRecordada.Password = CuentaPassword
-                Call GuardarCuenta(CuentaEmail, CuentaPassword)
-            Else
-                ' Reseteamos los datos de cuenta guardados
-                Call GuardarCuenta(vbNullString, vbNullString)
-            End If
-            If CheckUserDataLoged() = True Then
-                ModAuth.LoginOperation = e_operation.Authenticate
-                Call LoginOrConnect(E_MODO.IngresandoConCuenta)
-            End If
+    If IntervaloPermiteConectar Then
+        CuentaEmail = Account
+        CuentaPassword = Password
+        If storeCredentials Then
+            CuentaRecordada.nombre = CuentaEmail
+            CuentaRecordada.Password = CuentaPassword
+            Call GuardarCuenta(CuentaEmail, CuentaPassword)
+        Else
+            ' Reseteamos los datos de cuenta guardados
+            Call GuardarCuenta(vbNullString, vbNullString)
         End If
-    #End If
+        If CheckUserDataLoged() = True Then
+            ModAuth.LoginOperation = e_operation.Authenticate
+            Call LoginOrConnect(E_MODO.IngresandoConCuenta)
+        End If
+    End If
     Exit Sub
 DoLogin_Err:
     Call RegistrarError(Err.Number, Err.Description, "ModLogin.DoLogin", Erl)
@@ -469,11 +464,7 @@ Public Sub LoginCharacter(ByVal Name As String)
         ModAuth.LoginOperation = e_operation.Authenticate
         Call LoginOrConnect(E_MODO.Normal)
         
-        #If REMOTE_CLOSE = 0 Then
-            frmConnecting.Show False, frmConnect
-        #Else
-            Call SaveStringInFile("LoginCharacter: " & Name, "remote_debug.txt")
-        #End If
+        frmConnecting.Show False, frmConnect
     #End If
     Exit Sub
 LogearPersonaje_Err:
@@ -546,12 +537,10 @@ Public Sub OnClientDisconnect(ByVal Error As Long)
     Const WSAENETUNREACH     As Long = 10051
     Const WSAEHOSTUNREACH    As Long = 10065
 
-    #If REMOTE_CLOSE = 0 Then
+    frmConnect.MousePointer = 1
+    frmMain.ShowFPS.enabled = False
 
-        frmConnect.MousePointer = 1
-        frmMain.ShowFPS.enabled = False
-
-        Select Case Error
+    Select Case Error
 
             '----------------------------------------------------------
             ' SERVER REFUSED CONNECTION (immediate failure)
@@ -629,14 +618,8 @@ Public Sub OnClientDisconnect(ByVal Error As Long)
 
                 Exit Sub
 
-        End Select
+    End Select
 
-    #Else
-
-        frmDebug.add_text_tracebox "OnClientDisconnect " & Error
-        Call SaveStringInFile("OnClientDisconnect " & Error, "remote_debug.txt")
-        prgRun = False
-    #End If
     Exit Sub
 OnClientDisconnect_Err:
     Call RegistrarError(Err.Number, Err.Description, "ModLogin.OnClientDisconnect", Erl)

--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -49,34 +49,7 @@ Public Function HandleIncomingData(ByVal message As Network.Reader) As Boolean
     #End If
     Dim PacketId As Long
     PacketId = Reader.ReadInt16
-    #If REMOTE_CLOSE = 1 Then
-        Select Case PacketId
-            Case ServerPacketID.eConnected
-                Call HandleConnected
-                Call SaveStringInFile("Authenticated with server OK", "remote_debug.txt")
-            Case ServerPacketID.elogged
-                frmDebug.add_text_tracebox "Logged"
-                Dim res As Boolean
-                res = Reader.ReadBool
-                Call SaveStringInFile("Logged with character " & CharacterRemote, "remote_debug.txt")
-                InitiateShutdownProcess = True
-                ShutdownProcessTimer.start
-            Case ServerPacketID.eLocaleMsg
-                Dim chat      As String
-                Dim FontIndex As Integer
-                Dim str       As String
-                PacketId = Reader.ReadInt16()
-                chat = Reader.ReadString8()
-                FontIndex = Reader.ReadInt8()
-                Call SaveStringInFile(chat, "remote_debug.txt")
-            Case Else
-                'don't care, just consume
-                Do While (message.GetAvailable() > 0)
-                    PacketId = Reader.ReadInt8
-                Loop
-        End Select
-    #Else
-        Select Case PacketId
+    Select Case PacketId
             Case ServerPacketID.eConnected
                 Call HandleConnected
             Case ServerPacketID.elogged
@@ -484,7 +457,6 @@ Public Function HandleIncomingData(ByVal message As Network.Reader) As Boolean
             Case Else
                 ' Invalid Message
         End Select
-    #End If
     ' —————————————————————————————
     ' Detect both (a) extra bytes from known packets
     '         and (b) any packet where we had NO handler
@@ -515,7 +487,7 @@ Private Sub HandleConnected()
             Debug.Assert values(i) = i
         Next i
     #End If
-    #If REMOTE_CLOSE = 0 And FPSFLAG = 1 Then
+    #If FPSFLAG = 1 Then
         frmMain.ShowFPS.enabled = True
     #End If
     #If DIRECT_PLAY = 0 Then

--- a/CODIGO/Recursos.bas
+++ b/CODIGO/Recursos.bas
@@ -2380,32 +2380,30 @@ CargarAnimEscudos_Err:
 End Sub
 
 Sub LoadFonts()
-    #If REMOTE_CLOSE = 0 Then
-        If LoadFont("Cardo.ttf") Then
-            frmMain.NombrePJ.font.Name = "Cardo"
-        End If
-        If LoadFont("Alegreya Sans AO.ttf") Then
-            Dim CurControl As Control
-            Dim Middle     As Integer
-            For Each CurControl In frmMain.Controls
-                If CurControl.Name <> "NombrePJ" Then
-                    Select Case TypeName(CurControl)
-                        Case "Label"
-                            CurControl.font.Name = "Alegreya Sans AO"
-                            ' Centrar texto verticalmente
-                            If Not CurControl.AutoSize Then
-                                Middle = Fix(CurControl.Top + CurControl.Height * 0.5)
-                                CurControl.AutoSize = True
-                                CurControl.Top = Fix(Middle - CurControl.Height * 0.5)
-                            End If
-                        Case "RichTextBox", "ListBox"
-                            CurControl.font.Name = "Alegreya Sans AO"
-                    End Select
-                End If
-            Next
-            Call SelLineSpacing(frmMain.RecTxt, 5, 22)
-        End If
-    #End If
+    If LoadFont("Cardo.ttf") Then
+        frmMain.NombrePJ.font.Name = "Cardo"
+    End If
+    If LoadFont("Alegreya Sans AO.ttf") Then
+        Dim CurControl As Control
+        Dim Middle     As Integer
+        For Each CurControl In frmMain.Controls
+            If CurControl.Name <> "NombrePJ" Then
+                Select Case TypeName(CurControl)
+                    Case "Label"
+                        CurControl.font.Name = "Alegreya Sans AO"
+                        ' Centrar texto verticalmente
+                        If Not CurControl.AutoSize Then
+                            Middle = Fix(CurControl.Top + CurControl.Height * 0.5)
+                            CurControl.AutoSize = True
+                            CurControl.Top = Fix(Middle - CurControl.Height * 0.5)
+                        End If
+                    Case "RichTextBox", "ListBox"
+                        CurControl.font.Name = "Alegreya Sans AO"
+                End Select
+            End If
+        Next
+        Call SelLineSpacing(frmMain.RecTxt, 5, 22)
+    End If
     #If PYMMO = 1 Then
         Dim arr() As Byte
         ReDim arr(1 To 16) As Byte

--- a/CODIGO/engine.bas
+++ b/CODIGO/engine.bas
@@ -1959,44 +1959,6 @@ Public Function IsCharVisible(ByVal charindex As Integer) As Boolean
     End If
 End Function
 
-#If REMOTE_CLOSE = 1 Then
-Public Sub bot_main_loop()
-On Error GoTo Start_Err
-    Call Fonts.LoadFonts
-    prgRun = True
-    InitiateShutdownProcess = False
-    Dim countdown As Integer
-    countdown = 60
-    Do While prgRun
-        DoEvents
-        Call modNetwork.Poll
-        DoEvents
-        If InitiateShutdownProcess Then
-            If countdown > 0 And ShutdownProcessTimer.ElapsedSeconds > 5 Then
-                ShutdownProcessTimer.start
-                Call WriteGlobalMessage("WARNING: The server is going to close in " & countdown & " seconds for scheduled maintainance. Please disconnect from the game!!!")
-                frmDebug.add_text_tracebox "WARNING: The server is going to close in " & countdown & " seconds for scheduled maintainance. Please disconnect from the game!!!"
-                Call SaveStringInFile("WARNING: The server is going to close in " & countdown & " seconds for scheduled maintainance. Please disconnect from the game!!!", "remote_debug.txt")
-                countdown = countdown - 5
-            ElseIf countdown = 0 Then
-                Call WriteFeatureEnable("SGRACEFULLY", 1)
-                Call SaveStringInFile("Sent request to shutdown to the server", "remote_debug.txt")
-                countdown = -1
-            ElseIf countdown < 0 Then
-
-            End If
-            
-        End If
-    Loop
-
-    Exit Sub
-
-Start_Err:
-    Call RegistrarError(Err.Number, Err.Description, "engine.Start", Erl)
-    Resume Next
-    
-End Sub
-#End If
 
 Public Sub start()
     On Error GoTo Start_Err

--- a/CODIGO/frmConnect.frm
+++ b/CODIGO/frmConnect.frm
@@ -295,43 +295,33 @@ Private Sub AuthSocket_Error(ByVal Number As Integer, _
                              ByVal HelpFile As String, _
                              ByVal HelpContext As Long, _
                              CancelDisplay As Boolean)
-    #If REMOTE_CLOSE = 0 Then
-        
-        frmDebug.add_text_tracebox "AuthSocket_Error Number:" & Number & " Desc: " & Description
-        
-        Select Case Number
-        
-            Case 10060: ' Connect timeout
-                
-                    Dim nextIndex As Integer
-                    nextIndex = GetNextLoginServer(CurrentLoginServerIndex)
-                    
-                    ' No servers or only one server (would loop to the same)
-                    If nextIndex = -1 Or nextIndex = CurrentLoginServerIndex Then
-                        Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_SERVIDOR_OFFLINE"), False, SessionOpened)
-                        frmDebug.add_text_tracebox "No hay más Login Servers para reintentar."
-                        Exit Sub
-                    End If
-                    
-                    ' Switch to next login server
-                    CurrentLoginServerIndex = nextIndex
-                    IPdelServidorLogin = LoginServerIP(CurrentLoginServerIndex)
-                    PuertoDelServidorLogin = LoginServerPort(CurrentLoginServerIndex)
-                    
-                    frmDebug.add_text_tracebox "Reintentando con Login Server #" & CurrentLoginServerIndex & _
-                                               " -> " & IPdelServidorLogin & ":" & PuertoDelServidorLogin
-                    
-                
-                    
-                    Call connectToLoginServer
-                
-        End Select
-        
-    #Else
-        frmDebug.add_text_tracebox "SERVIDOR OFFLINE"
-        Call SaveStringInFile("AuthSocket_Error: " & Description, "remote_debug.txt")
-        prgRun = False
-    #End If
+    frmDebug.add_text_tracebox "AuthSocket_Error Number:" & Number & " Desc: " & Description
+
+    Select Case Number
+
+        Case 10060: ' Connect timeout
+
+                Dim nextIndex As Integer
+                nextIndex = GetNextLoginServer(CurrentLoginServerIndex)
+
+                ' No servers or only one server (would loop to the same)
+                If nextIndex = -1 Or nextIndex = CurrentLoginServerIndex Then
+                    Call TextoAlAsistente(JsonLanguage.Item("MENSAJEBOX_SERVIDOR_OFFLINE"), False, SessionOpened)
+                    frmDebug.add_text_tracebox "No hay más Login Servers para reintentar."
+                    Exit Sub
+                End If
+
+                ' Switch to next login server
+                CurrentLoginServerIndex = nextIndex
+                IPdelServidorLogin = LoginServerIP(CurrentLoginServerIndex)
+                PuertoDelServidorLogin = LoginServerPort(CurrentLoginServerIndex)
+
+                frmDebug.add_text_tracebox "Reintentando con Login Server #" & CurrentLoginServerIndex & _
+                                           " -> " & IPdelServidorLogin & ":" & PuertoDelServidorLogin
+
+                Call connectToLoginServer
+
+    End Select
 End Sub
 
 Private Sub Form_KeyDown(KeyCode As Integer, Shift As Integer)


### PR DESCRIPTION
### Motivation
- Remove legacy client-side code paths that were guarded by `REMOTE_CLOSE` which are no longer used by the server-side and add dead branches and unused symbols to the client.
- Keep the existing production login/connect/disconnect behavior intact while removing remote-only debug/bot/startup paths.
- Simplify conditional compilation so normal runtime behavior is not split by obsolete remote-close flags.

### Description
- Deleted the REMOTE_CLOSE-only startup, command-line parsing and remote debug flow by removing `parse_cmd_line_args`, the remote startup branch in `Main`, and the `LoginCharacter(CharacterRemote)` auto-login path; the changes touch `CODIGO/General.bas` and `CODIGO/ModAuth.bas`.
- Removed obsolete globals and conditional declarations used only for remote-close: `CharacterRemote`, `InitiateShutdownProcess`, and `ShutdownProcessTimer`; these changes are in `CODIGO/Declares.bas` and `CODIGO/engine.bas` (bot loop removal).
- Flattened packet dispatch and socket/error handling by removing the REMOTE_CLOSE-specific packet branch and remote-debug branches while preserving the normal handler table and error UI paths; modifications are in `CODIGO/Protocol.bas`, `CODIGO/ModLogin.bas`, and `CODIGO/frmConnect.frm`.
- Unwrapped formerly-guarded client UI/resource code (font loading) so it runs unconditionally, and removed remote-debug file writes and bot shutdown loop; this affects `CODIGO/Recursos.bas` and `CODIGO/engine.bas`.
- Files modified: `CODIGO/Declares.bas`, `CODIGO/General.bas`, `CODIGO/ModAuth.bas`, `CODIGO/ModLogin.bas`, `CODIGO/Protocol.bas`, `CODIGO/Recursos.bas`, `CODIGO/engine.bas`, and `CODIGO/frmConnect.frm`.

### Testing
- Ran a repository-wide search for `REMOTE_CLOSE`, `RemoteClose`, `remote close`, related debug symbols and runtime names and confirmed there are no remaining client references to the removed remote-close support.
- Ran a conditional-compilation balance checker (Python) across `CODIGO/*.bas/.frm/.cls` and confirmed all `#If/#Else/#End If` blocks are balanced.
- Ran `git diff --check` and repository integrity checks to ensure no leftover whitespace/merge issues were introduced.
- Attempted to verify VB6 project compilation with `wine VB6.EXE /make Argentum20.vbp` but could not run the VB6 build in this environment because `wine`/VB6 is not available, so a local VB6 compile is still required to fully validate the project binary build.

No REMOTE_CLOSE definition/reference remains in the client source after these changes; the VB6 project file did not contain a `REMOTE_CLOSE` CondComp entry to remove.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1de7827d808328ac2e5f732fb98bae)