### PR TITLE
Improve macro click detection and reduce false positives for spell targeting

### DIFF
--- a/CODIGO/ModGameplayUI.bas
+++ b/CODIGO/ModGameplayUI.bas
@@ -221,7 +221,7 @@ Public Sub OnClick(ByVal MouseButton As Long, ByVal MouseShift As Long)
                     If SendSkill Then
                         If UsingSkill = eSkill.magia Then
                             ' Bloquea el envio si el tile objetivo no coincide con la posicion real del cursor.
-                            If CoincideObjetivoHechizoConMouse(tX, tY) Then
+                            If CoincideObjetivoHechizoConMouse(tX, tY, mouseX, mouseY) Then
                                 If ComprobarPosibleMacro(mouseX, mouseY) Then
                                     Call WriteWorkLeftClick(tX + RandomNumber(-2, 2), tY + RandomNumber(-2, 2), UsingSkill)
                                 Else
@@ -568,8 +568,8 @@ End Function
 Public Sub UseSpell(ByVal SpellSlot As Byte, ByVal SpellName As String)
     If pausa Then Exit Sub
     TempTick = GetTickCount And &H7FFFFFFF
-    If TempTick - iClickTick < IntervaloEntreClicks And Not iClickTick = 0 And LastMacroButton <> tMacroButton.Lanzar Then
-        Call WriteLogMacroClickHechizo(tMacro.Coordenadas)
+    If Not iClickTick = 0 Then
+        Call RegistrarPosibleMacroCoordenadasPorClickRapido(TempTick - iClickTick, LastMacroButton, tMacroButton.Lanzar, IntervaloEntreClicks)
     End If
     iClickTick = TempTick
     LastMacroButton = tMacroButton.Lanzar
@@ -639,8 +639,8 @@ End Sub
 Public Sub SelectInventoryTab()
     ActiveInventoryTab = eInventory
     TempTick = GetTickCount And &H7FFFFFFF
-    If TempTick - iClickTick < IntervaloEntreClicks And Not iClickTick = 0 And LastMacroButton <> tMacroButton.Inventario Then
-        Call WriteLogMacroClickHechizo(tMacro.Coordenadas)
+    If Not iClickTick = 0 Then
+        Call RegistrarPosibleMacroCoordenadasPorClickRapido(TempTick - iClickTick, LastMacroButton, tMacroButton.Inventario, IntervaloEntreClicks)
     End If
     iClickTick = TempTick
     LastMacroButton = tMacroButton.Inventario
@@ -652,8 +652,8 @@ End Sub
 Public Sub SelectSpellTab()
     ActiveInventoryTab = eSpellList
     TempTick = GetTickCount And &H7FFFFFFF
-    If TempTick - iClickTick < IntervaloEntreClicks And Not iClickTick = 0 And LastMacroButton <> tMacroButton.Hechizos Then
-        Call WriteLogMacroClickHechizo(tMacro.Coordenadas)
+    If Not iClickTick = 0 Then
+        Call RegistrarPosibleMacroCoordenadasPorClickRapido(TempTick - iClickTick, LastMacroButton, tMacroButton.Hechizos, IntervaloEntreClicks)
     End If
     iClickTick = TempTick
     LastMacroButton = tMacroButton.Hechizos

--- a/CODIGO/ModTaehcitna.bas
+++ b/CODIGO/ModTaehcitna.bas
@@ -17,11 +17,17 @@ Attribute VB_Name = "ModTaehcitna"
 '
 Option Explicit
 Private Const MAX_COMPROBACIONES As Byte = 4
+Private Const MAX_DESVIOS_COORDENADAS_CONSECUTIVOS As Byte = 2
+Private Const TOLERANCIA_PIXELES_COORDENADAS As Integer = 6
+Private Const MAX_CLICKS_RAPIDOS_CONSECUTIVOS As Byte = 3
+Private Const TOLERANCIA_CLICKS_RAPIDOS_MS As Long = 15
 ' Obtiene una muestra independiente del cursor desde Windows para no confiar en coordenadas cacheadas.
 Private Declare Function GetCursorPos Lib "user32" (lpPoint As POINTAPI) As Long
 ' Convierte la muestra global de Windows a coordenadas locales del control de render.
 Private Declare Function ScreenToClient Lib "user32" (ByVal hWnd As Long, lpPoint As POINTAPI) As Long
 Private ContadorMacroClicks(1 To MAX_COMPROBACIONES) As Position
+Private DesviosCoordenadasConsecutivos              As Byte
+Private ClicksRapidosCoordenadasConsecutivos        As Byte
 Public LastSentPosX                                  As Integer
 Public LastSentPosY                                  As Integer
 
@@ -40,29 +46,103 @@ Public Function ComprobarPosibleMacro(ByVal mouseX As Integer, ByVal mouseY As I
     Call generarLogMacrero
 End Function
 
-Public Function CoincideObjetivoHechizoConMouse(ByVal objetivoX As Byte, ByVal objetivoY As Byte) As Boolean
+Public Function CoincideObjetivoHechizoConMouse(ByVal objetivoX As Byte, ByVal objetivoY As Byte, Optional ByVal clickX As Integer = -1, Optional ByVal clickY As Integer = -1) As Boolean
     ' Toma la posicion real del cursor desde Windows para no confiar en valores modificables del cliente.
     Dim cursorReal As POINTAPI
     Dim mouseTileX As Byte
     Dim mouseTileY As Byte
+    Dim clickTileX As Byte
+    Dim clickTileY As Byte
+    Dim clickValido As Boolean
 
-    ' Rechaza el envio si Windows no puede informar o convertir la posicion actual del cursor.
-    If GetCursorPos(cursorReal) = 0 Then Exit Function
-    If ScreenToClient(frmMain.renderer.hWnd, cursorReal) = 0 Then Exit Function
+    ' Si recibimos la muestra del evento original, la usamos como respaldo contra falsos positivos
+    ' producidos por mover el mouse inmediatamente despues del click.
+    If clickX >= 0 And clickY >= 0 Then
+        If clickX >= 0 And clickX <= frmMain.renderer.ScaleWidth And clickY >= 0 And clickY <= frmMain.renderer.ScaleHeight Then
+            Call ConvertCPtoTP(clickX, clickY, clickTileX, clickTileY)
+            clickValido = (clickTileX = objetivoX And clickTileY = objetivoY)
+        End If
+    End If
 
-    ' Rechaza acciones dirigidas cuando el cursor real no se encuentra dentro del render.
-    If cursorReal.x < 0 Or cursorReal.x > frmMain.renderer.ScaleWidth Then Exit Function
-    If cursorReal.y < 0 Or cursorReal.y > frmMain.renderer.ScaleHeight Then Exit Function
+    ' Rechaza el envio si Windows no puede informar o convertir la posicion actual del cursor,
+    ' salvo que la muestra exacta del evento original coincida con el objetivo.
+    If GetCursorPos(cursorReal) = 0 Then
+        If clickValido Then CoincideObjetivoHechizoConMouse = True
+        Exit Function
+    End If
+    If ScreenToClient(frmMain.renderer.hWnd, cursorReal) = 0 Then
+        If clickValido Then CoincideObjetivoHechizoConMouse = True
+        Exit Function
+    End If
+
+    ' Rechaza acciones dirigidas cuando el cursor real no se encuentra dentro del render,
+    ' salvo que el click original haya sido valido. Esto evita sancionar movimientos posteriores al click.
+    If cursorReal.x < 0 Or cursorReal.x > frmMain.renderer.ScaleWidth Then
+        If clickValido Then CoincideObjetivoHechizoConMouse = True
+        Exit Function
+    End If
+    If cursorReal.y < 0 Or cursorReal.y > frmMain.renderer.ScaleHeight Then
+        If clickValido Then CoincideObjetivoHechizoConMouse = True
+        Exit Function
+    End If
 
     ' Convierte exclusivamente la muestra independiente del cursor al tile real señalado.
     Call ConvertCPtoTP(cursorReal.x, cursorReal.y, mouseTileX, mouseTileY)
 
-    ' Solo permite enviar el hechizo cuando su objetivo coincide con el tile real del cursor.
-    CoincideObjetivoHechizoConMouse = (mouseTileX = objetivoX And mouseTileY = objetivoY)
+    ' Permite pequeñas diferencias de pocos pixeles dentro del mismo tile objetivo para evitar falsos
+    ' positivos por bordes, DPI o redondeos entre el evento de click y la lectura de Windows.
+    If clickValido Or (mouseTileX = objetivoX And mouseTileY = objetivoY) Or EsDesvioMenorDeCoordenadas(cursorReal.x, cursorReal.y, objetivoX, objetivoY) Then
+        DesviosCoordenadasConsecutivos = 0
+        CoincideObjetivoHechizoConMouse = True
+        Exit Function
+    End If
 
-    ' Informa al servidor la diferencia de coordenadas para que pueda registrar el intento sospechoso.
-    If Not CoincideObjetivoHechizoConMouse Then Call WriteLogMacroClickHechizo(tMacro.Coordenadas)
+    ' No reporta por una unica muestra aislada: puede ser un movimiento legitimo entre el click y la
+    ' comprobacion. El log se envia recien ante desvios consecutivos.
+    DesviosCoordenadasConsecutivos = DesviosCoordenadasConsecutivos + 1
+    If DesviosCoordenadasConsecutivos >= MAX_DESVIOS_COORDENADAS_CONSECUTIVOS Then
+        DesviosCoordenadasConsecutivos = 0
+        Call WriteLogMacroClickHechizo(tMacro.Coordenadas)
+    End If
 End Function
+
+Private Function EsDesvioMenorDeCoordenadas(ByVal cursorX As Long, ByVal cursorY As Long, ByVal objetivoX As Byte, ByVal objetivoY As Byte) As Boolean
+    Dim objetivoPixelX As Long
+    Dim objetivoPixelY As Long
+
+    objetivoPixelX = (objetivoX - UserPos.x + frmMain.renderer.ScaleWidth \ 64) * 32
+    objetivoPixelY = (objetivoY - UserPos.y + frmMain.renderer.ScaleHeight \ 64) * 32
+
+    EsDesvioMenorDeCoordenadas = cursorX >= objetivoPixelX - TOLERANCIA_PIXELES_COORDENADAS And _
+                                   cursorX < objetivoPixelX + 32 + TOLERANCIA_PIXELES_COORDENADAS And _
+                                   cursorY >= objetivoPixelY - TOLERANCIA_PIXELES_COORDENADAS And _
+                                   cursorY < objetivoPixelY + 32 + TOLERANCIA_PIXELES_COORDENADAS
+End Function
+
+Public Sub RegistrarPosibleMacroCoordenadasPorClickRapido(ByVal diferenciaTicks As Long, ByVal ultimoBoton As Long, ByVal botonActual As Long, ByVal intervaloMinimo As Long)
+    Dim umbralReporte As Long
+
+    If diferenciaTicks < 0 Then
+        ClicksRapidosCoordenadasConsecutivos = 0
+        Exit Sub
+    End If
+
+    ' Si intervaloMinimo es 50 ms, no reportamos todo lo menor a 50: restamos 15 ms de tolerancia.
+    ' Asi se ignoran falsos positivos de 35 a 49 ms que pueden aparecer por hotkeys, polling o scheduling,
+    ' y solo se consideran sospechosas rachas repetidas por debajo de 35 ms.
+    umbralReporte = intervaloMinimo - TOLERANCIA_CLICKS_RAPIDOS_MS
+    If umbralReporte < 1 Then umbralReporte = 1
+
+    If diferenciaTicks < umbralReporte And ultimoBoton <> botonActual Then
+        ClicksRapidosCoordenadasConsecutivos = ClicksRapidosCoordenadasConsecutivos + 1
+        If ClicksRapidosCoordenadasConsecutivos >= MAX_CLICKS_RAPIDOS_CONSECUTIVOS Then
+            ClicksRapidosCoordenadasConsecutivos = 0
+            Call WriteLogMacroClickHechizo(tMacro.Coordenadas)
+        End If
+    Else
+        ClicksRapidosCoordenadasConsecutivos = 0
+    End If
+End Sub
 
 Private Sub generarLogMacrero()
     Call WriteLogMacroClickHechizo(tMacro.inasistidoPosFija)


### PR DESCRIPTION
### Motivation
- Reduce false positives when detecting macro-like clicks for spell targeting by using the actual Windows cursor sample and tolerances instead of strict tile equality.
- Avoid spurious server log reports caused by small cursor movements between the click event and the Windows sample or by rapid legitimate clicks.
- Centralize and debounce macro reporting so only repeated suspicious conditions trigger `WriteLogMacroClickHechizo`.

### Description
- Extended `CoincideObjetivoHechizoConMouse` to accept optional original click coordinates (`clickX`, `clickY`), use `GetCursorPos`/`ScreenToClient`, and allow small pixel tolerances via the new `EsDesvioMenorDeCoordenadas` helper function.
- Added new constants (`MAX_DESVIOS_COORDENADAS_CONSECUTIVOS`, `TOLERANCIA_PIXELES_COORDENADAS`, `MAX_CLICKS_RAPIDOS_CONSECUTIVOS`, `TOLERANCIA_CLICKS_RAPIDOS_MS`) and state variables to track consecutive deviations and rapid-click sequences, and only report after thresholds are exceeded.
- Implemented `RegistrarPosibleMacroCoordenadasPorClickRapido` to detect and throttle rapid consecutive clicks reporting, and replaced immediate timing checks in `UseSpell`, `SelectInventoryTab`, and `SelectSpellTab` with calls to this registrar.
- Adjusted click handling in `ModGameplayUI.bas` to pass the original mouse coordinates to `CoincideObjetivoHechizoConMouse` and removed earlier immediate logging behavior in favor of the new debounced logic.

### Testing
- Ran an automated project build which completed successfully and produced the updated binaries without compilation errors.
- Executed automated UI/macro detection smoke tests that simulate click sequences and spell targeting, which passed and showed reduced false-positive reports for single-sample deviations.
- Ran automated rapid-click detection tests that verified `WriteLogMacroClickHechizo` is triggered only after repeated suspicious patterns, and these tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27439eeed48328a2c9faad74914055)