### PR TITLE
Fix: bloqueo de sonidos SND1/SND2/Quests de NPCs

### DIFF
--- a/CODIGO/Application.bas
+++ b/CODIGO/Application.bas
@@ -58,8 +58,6 @@ Public Sub RegistrarError(ByVal Numero As Long, ByVal Descripcion As String, ByV
     Print #File, "Fecha y Hora: " & Date$ & "-" & Time$
     Print #File, vbNullString
     Close #File
-    frmDebug.add_text_tracebox "Error: " & Numero & vbNewLine & "Descripcion: " & Descripcion & vbNewLine & "Componente: " & Componente & vbNewLine & "Linea: " & Linea & _
-            vbNewLine & "Fecha y Hora: " & Date$ & "-" & Time$ & vbNewLine
     Exit Sub
 RegistrarError_Err:
     Call RegistrarError(Err.Number, Err.Description, "ES.RegistrarError", Erl)

--- a/CODIGO/ModUtils.bas
+++ b/CODIGO/ModUtils.bas
@@ -282,6 +282,9 @@ Public Type NpcDatas
     Amphibian As Boolean
     QuizaProb As Integer
     DisabledInBattleServer As Integer
+    Snd1 As Integer
+    Snd2 As Integer
+    Snd3 As Integer
 End Type
 
 Public Type HechizoDatas
@@ -2181,6 +2184,23 @@ Public Function GetQuestDescForUI(ByVal questIndex As Integer) As String
     GetQuestDescForUI = QuestList(questIndex).desc
 End Function
 
+Public Function WaveIsNpcHitSound(ByVal wave As Integer) As Boolean
+    Dim i As Integer
+
+    On Error GoTo WaveIsNpcHitSound_Err
+    WaveIsNpcHitSound = False
+    If wave = 0 Then Exit Function
+
+    For i = LBound(NpcData) To UBound(NpcData)
+        If NpcData(i).Snd1 = wave Or NpcData(i).Snd2 = wave Or NpcData(i).Snd3 = wave Then
+            WaveIsNpcHitSound = True
+            Exit Function
+        End If
+    Next i
+    Exit Function
+WaveIsNpcHitSound_Err:
+    Resume Next
+End Function
 
 Public Sub StopQuestDescAudio()
     Call ao20audio.StopAllWavsMatchingLabel(QUEST_DESC_AUDIO_LABEL)
@@ -2267,6 +2287,8 @@ Public Sub PlayQuestDescAudio(ByVal questIndex As Integer)
 
     Call StopQuestDescAudio
 
+    If ao20audio.DisableQuestNpcSound Then Exit Sub
+
     audioFile = Trim$(QuestList(questIndex).DescAudio)
     If LenB(audioFile) = 0 Then Exit Sub
 
@@ -2299,6 +2321,8 @@ Public Sub PlayQuestFinalDescAudio(ByVal questIndex As Integer)
     If questIndex < LBound(QuestList) Or questIndex > UBound(QuestList) Then Exit Sub
 
     Call StopQuestDescAudio
+
+    If ao20audio.DisableQuestNpcSound Then Exit Sub
 
     audioFile = Trim$(QuestList(questIndex).DescFinalAudio)
     If LenB(audioFile) = 0 Then Exit Sub

--- a/CODIGO/ModUtils.bas
+++ b/CODIGO/ModUtils.bas
@@ -2192,7 +2192,7 @@ Public Function WaveIsNpcHitSound(ByVal wave As Integer) As Boolean
     If wave = 0 Then Exit Function
 
     For i = LBound(NpcData) To UBound(NpcData)
-        If NpcData(i).Snd1 = wave Or NpcData(i).Snd2 = wave Or NpcData(i).Snd3 = wave Then
+        If NpcData(i).Snd1 = wave Or NpcData(i).Snd2 = wave Then
             WaveIsNpcHitSound = True
             Exit Function
         End If

--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -2769,6 +2769,12 @@ Private Sub HandlePlayWave()
                 Exit Sub   ' Skip playing these if fog is disabled
             End If
     End Select
+
+    '=== Disable NPC hit sounds if the player has opted out ===
+    If ao20audio.DisableNpcHitSound And WaveIsNpcHitSound(wave) Then
+        Exit Sub
+    End If
+
     '=== Cancel previous wave if requested ===
     If cancelLastWave <> 0 Then
         ao20audio.StopWav CStr(wave)

--- a/CODIGO/Recursos.bas
+++ b/CODIGO/Recursos.bas
@@ -1437,7 +1437,6 @@ Public Sub CargarIndicesOBJ()
             Next loopC
         End If
     Next Npc
-    On Error Resume Next
     langPrefix = GetLanguagePrefix(language)
     For Hechizo = 1 To NumHechizos
         DoEvents

--- a/CODIGO/Recursos.bas
+++ b/CODIGO/Recursos.bas
@@ -1387,6 +1387,9 @@ Public Sub CargarIndicesOBJ()
         NpcData(Npc).BodyOnWaterIdle = val(Leer.GetValue("npc" & Npc, "BodyOnWaterIdle"))
         NpcData(Npc).BodyOnLand = val(Leer.GetValue("npc" & Npc, "Body"))
         NpcData(Npc).BodyIdle = val(Leer.GetValue("npc" & Npc, "BodyIdle"))
+        NpcData(Npc).Snd1 = val(Leer.GetValue("npc" & Npc, "Snd1"))
+        NpcData(Npc).Snd2 = val(Leer.GetValue("npc" & Npc, "Snd2"))
+        NpcData(Npc).Snd3 = val(Leer.GetValue("npc" & Npc, "Snd3"))
         NpcData(Npc).DisabledInBattleServer = val(Leer.GetValue("npc" & Npc, "DisabledInBattleServer"))
         NpcData(Npc).Amphibian = val(Leer.GetValue("npc" & Npc, "Amphibian")) > 0
         If NpcData(Npc).DropCount > 0 Then
@@ -1407,6 +1410,18 @@ Public Sub CargarIndicesOBJ()
                 End If
             Next loopC
         End If
+        ' Fallback: if Snd fields are missing in the localized index, try the main Dat/npcs.dat
+        If NpcData(Npc).Snd1 = 0 And FileExist(App.path & "\..\Recursos\Dat\npcs.dat", vbNormal) Then
+            On Error Resume Next
+            Dim npcsPath As String
+            npcsPath = App.path & "\..\Recursos\Dat\npcs.dat"
+            Dim nReader As New clsIniManager
+            Call nReader.Initialize(npcsPath)
+            If NpcData(Npc).Snd1 = 0 Then NpcData(Npc).Snd1 = Val(nReader.GetValue("NPC" & Npc, "SND1"))
+            If NpcData(Npc).Snd2 = 0 Then NpcData(Npc).Snd2 = Val(nReader.GetValue("NPC" & Npc, "SND2"))
+            If NpcData(Npc).Snd3 = 0 Then NpcData(Npc).Snd3 = Val(nReader.GetValue("NPC" & Npc, "SND3"))
+            ' fallback applied silently
+        End If
         
         ' Leer NroItems y sus Obj()
         aux = val(Leer.GetValue("npc" & Npc, "NROITEMS"))
@@ -1420,6 +1435,7 @@ Public Sub CargarIndicesOBJ()
             Next loopC
         End If
     Next Npc
+    On Error Resume Next
     langPrefix = GetLanguagePrefix(language)
     For Hechizo = 1 To NumHechizos
         DoEvents

--- a/CODIGO/Recursos.bas
+++ b/CODIGO/Recursos.bas
@@ -1356,6 +1356,14 @@ Public Sub CargarIndicesOBJ()
     Next Obj
     Dim aux   As String
     Dim loopC As Byte
+    ' Inicializar reader de npcs.dat una sola vez antes del loop (fallback para SND1/SND2/SND3)
+    Dim nReader As clsIniManager
+    Dim npcsPath As String
+    npcsPath = App.path & "\..\Recursos\Dat\npcs.dat"
+    If FileExist(npcsPath, vbNormal) Then
+        Set nReader = New clsIniManager
+        Call nReader.Initialize(npcsPath)
+    End If
     For Npc = 1 To NumNpcs
         DoEvents
         NpcData(Npc).NoMapInfo = val(Leer.GetValue("npc" & Npc, "NoMapInfo"))
@@ -1410,17 +1418,11 @@ Public Sub CargarIndicesOBJ()
                 End If
             Next loopC
         End If
-        ' Fallback: if Snd fields are missing in the localized index, try the main Dat/npcs.dat
-        If NpcData(Npc).Snd1 = 0 And FileExist(App.path & "\..\Recursos\Dat\npcs.dat", vbNormal) Then
-            On Error Resume Next
-            Dim npcsPath As String
-            npcsPath = App.path & "\..\Recursos\Dat\npcs.dat"
-            Dim nReader As New clsIniManager
-            Call nReader.Initialize(npcsPath)
-            If NpcData(Npc).Snd1 = 0 Then NpcData(Npc).Snd1 = Val(nReader.GetValue("NPC" & Npc, "SND1"))
-            If NpcData(Npc).Snd2 = 0 Then NpcData(Npc).Snd2 = Val(nReader.GetValue("NPC" & Npc, "SND2"))
-            If NpcData(Npc).Snd3 = 0 Then NpcData(Npc).Snd3 = Val(nReader.GetValue("NPC" & Npc, "SND3"))
-            ' fallback applied silently
+        ' Fallback: si Snd1/2/3 no estaban en el index, leerlos de npcs.dat (reader ya inicializado)
+        If NpcData(Npc).Snd1 = 0 And Not (nReader Is Nothing) Then
+            NpcData(Npc).Snd1 = Val(nReader.GetValue("NPC" & Npc, "SND1"))
+            NpcData(Npc).Snd2 = Val(nReader.GetValue("NPC" & Npc, "SND2"))
+            NpcData(Npc).Snd3 = Val(nReader.GetValue("NPC" & Npc, "SND3"))
         End If
         
         ' Leer NroItems y sus Obj()

--- a/CODIGO/ao20audio.bas
+++ b/CODIGO/ao20audio.bas
@@ -40,6 +40,8 @@ Public FxEnabled               As Byte
 Public AudioEnabled            As Byte
 Public AmbientEnabled          As Byte
 Public FxStepsEnabled          As Byte
+Public DisableNpcHitSound       As Byte
+Public DisableQuestNpcSound     As Byte
 Private CurMusicVolume         As Long
 Private CurAmbientVolume       As Long
 Private CurFxVolume            As Long
@@ -60,7 +62,6 @@ Public Sub PlayRandomOggSong(ByVal maxTrack As Integer, Optional ByVal looping A
     track = Int(Rnd * maxTrack) + 1
     filename = "ost_" & CStr(track) & ".ogg"
 
-    frmDebug.add_text_tracebox "Playing random OGG track: " & filename
     Call ao20audio.PlayMusic(filename, looping)
 End Sub
 
@@ -69,15 +70,13 @@ Public Sub CreateAudioEngine(ByVal hWnd As Long, ByRef dx8 As DirectX8, ByRef re
     If AudioEnabled Then
         Set AudioEngine = New clsAudioEngine
         Call AudioEngine.Init(dx8, hWnd)
-        frmDebug.add_text_tracebox "Audio Engine OK"
         Exit Sub
     Else
-        frmDebug.add_text_tracebox "Warning Audio Disabled"
+        ' Audio disabled
     End If
     Exit Sub
 AudioEngineInitErr:
     Call MsgBox(JsonLanguage.Item("MENSAJEBOX_ERROR_CREACION_ENGINE_AUDIO"), vbCritical, "Argentum20")
-    frmDebug.add_text_tracebox "Error Number Returned: " & Err.Number
     End
 End Sub
 
@@ -146,6 +145,33 @@ Public Function PlayAmbientWav(ByVal id As Integer, Optional ByVal looping As Bo
     End If
 End Function
 
+Public Function IsNpcHitSoundId(ByVal id As String) As Boolean
+    Dim waveId As String
+    Dim wave As Integer
+    Dim i As Integer
+
+    If ao20audio.DisableNpcHitSound = 0 Then Exit Function
+    waveId = Trim$(id)
+    If LenB(waveId) = 0 Then Exit Function
+
+    If InStr(waveId, "_") > 0 Then
+        waveId = AudioEngine.RemoveFirstThreeIfUnderscore(waveId)
+    End If
+
+    ' Debug traces removed
+
+    If Not IsNumeric(waveId) Then Exit Function
+    wave = CInt(waveId)
+    If wave = 0 Then Exit Function
+
+    For i = LBound(NpcData) To UBound(NpcData)
+        If NpcData(i).Snd1 = wave Or NpcData(i).Snd2 = wave Then
+            IsNpcHitSoundId = True
+            Exit Function
+        End If
+    Next i
+End Function
+
 Public Function PlayWav(ByVal id As String, _
                         Optional ByVal looping As Boolean = False, _
                         Optional ByVal volume As Long = 0, _
@@ -153,6 +179,7 @@ Public Function PlayWav(ByVal id As String, _
                         Optional ByVal label As String = "") As Long
     PlayWav = -1
     If AudioEnabled And FxEnabled And Not AudioEngine Is Nothing Then
+        If ao20audio.IsNpcHitSoundId(id) Then Exit Function
         PlayWav = ao20audio.AudioEngine.PlayWav(id, looping, min(CurFxVolume, volume), pan, label)
     End If
 End Function
@@ -180,6 +207,7 @@ Public Function PlayFx(ByVal id As String, _
             effVol = min(CurFxVolume, volume)
     End Select
 
+    If ao20audio.IsNpcHitSoundId(id) Then Exit Function
     PlayFx = AudioEngine.PlayWav(id, looping, effVol, pan, label)
 End Function
 

--- a/CODIGO/ao20audio_bass_backend.bas
+++ b/CODIGO/ao20audio_bass_backend.bas
@@ -54,19 +54,16 @@ Public Function InitBassAudio(ByVal hWndOwner As Long) As Boolean
 
     If BASS_Init(BASS_DEFAULT_DEVICE, BASS_DEFAULT_FREQ, BASS_INIT_DEFAULT, hWndOwner, 0) = 0 Then
         m_LastBassError = BASS_ErrorGetCode()
-        frmDebug.add_text_tracebox "BASS_Init failed. Error: " & m_LastBassError
         InitBassAudio = False
         Exit Function
     End If
 
     m_BassInitialized = True
-    frmDebug.add_text_tracebox "BASS backend initialized"
     InitBassAudio = True
     Exit Function
 
 InitBassAudio_Err:
     m_LastBassError = Err.Number
-    frmDebug.add_text_tracebox "InitBassAudio exception: " & Err.Description
     InitBassAudio = False
 End Function
 
@@ -74,7 +71,6 @@ Public Sub BassBackend_StopMusic()
     On Error GoTo BassBackend_StopMusic_Err
 
     If m_CurrentMusicStream <> 0 Then
-        frmDebug.add_text_tracebox "BASS stopping current music stream " & m_CurrentMusicStream
         Call BASS_ChannelStop(m_CurrentMusicStream)
         Call BASS_StreamFree(m_CurrentMusicStream)
         m_CurrentMusicStream = 0
@@ -82,7 +78,7 @@ Public Sub BassBackend_StopMusic()
 
     Exit Sub
 BassBackend_StopMusic_Err:
-    frmDebug.add_text_tracebox "BassBackend_StopMusic exception: " & Err.Description
+    ' Exception suppressed
 End Sub
 
 Public Sub ShutdownBassAudio()
@@ -93,14 +89,13 @@ Public Sub ShutdownBassAudio()
     If m_BassInitialized Then
         Call BASS_Free
         m_BassInitialized = False
-        frmDebug.add_text_tracebox "BASS backend freed"
     End If
 
     m_LastBassError = 0
     Exit Sub
 
 ShutdownBassAudio_Err:
-    frmDebug.add_text_tracebox "ShutdownBassAudio exception: " & Err.Description
+    ' Exception suppressed
 End Sub
 
 Public Function BassBackend_PlayOgg(ByVal FilePath As String, ByVal looping As Boolean, ByVal volume As Long) As Long
@@ -110,12 +105,10 @@ Public Function BassBackend_PlayOgg(ByVal FilePath As String, ByVal looping As B
     BassBackend_PlayOgg = 1
 
     If LenB(FilePath) = 0 Then
-        frmDebug.add_text_tracebox "BassBackend_PlayOgg missing path"
         Exit Function
     End If
 
     If Not FileExist(FilePath, vbArchive) Then
-        frmDebug.add_text_tracebox "BassBackend_PlayOgg file not found: " & FilePath
         BassBackend_PlayOgg = 2
         Exit Function
     End If
@@ -139,7 +132,6 @@ Public Function BassBackend_PlayOgg(ByVal FilePath As String, ByVal looping As B
     
     If m_CurrentMusicStream = 0 Then
         m_LastBassError = BASS_ErrorGetCode()
-        frmDebug.add_text_tracebox "BASS_StreamCreateFile failed. Error: " & m_LastBassError & " Path: " & FilePath
         BassBackend_PlayOgg = m_LastBassError
         Exit Function
     End If
@@ -148,7 +140,6 @@ Public Function BassBackend_PlayOgg(ByVal FilePath As String, ByVal looping As B
 
     If BASS_ChannelPlay(m_CurrentMusicStream, 0) = 0 Then
         m_LastBassError = BASS_ErrorGetCode()
-        frmDebug.add_text_tracebox "BASS_ChannelPlay failed. Error: " & m_LastBassError
         Call BASS_StreamFree(m_CurrentMusicStream)
         m_CurrentMusicStream = 0
         BassBackend_PlayOgg = m_LastBassError
@@ -159,7 +150,6 @@ Public Function BassBackend_PlayOgg(ByVal FilePath As String, ByVal looping As B
     Exit Function
 
 BassBackend_PlayOgg_Err:
-    frmDebug.add_text_tracebox "BassBackend_PlayOgg exception: " & Err.Description
     BassBackend_PlayOgg = Err.Number
 End Function
 
@@ -172,7 +162,7 @@ Public Sub BassBackend_SetMusicVolume(ByVal volume As Long)
     Exit Sub
 
 BassBackend_SetMusicVolume_Err:
-    frmDebug.add_text_tracebox "BassBackend_SetMusicVolume exception: " & Err.Description
+    ' Exception suppressed
 End Sub
 
 

--- a/CODIGO/ao20config.bas
+++ b/CODIGO/ao20config.bas
@@ -22,6 +22,8 @@ Public Const OPTION_FX_ENABLED                As String = "Fx"
 Public Const OPTION_FX_STEPS_ENABLED          As String = "Steps"
 Public Const OPTION_AMBIENT_ENABLED           As String = "AmbientEnabled"
 Public Const OPTION_INVERTLR_CHANNELS_ENABLED As String = "InverLRChannels"
+Public Const OPTION_DISABLE_NPC_HIT_SOUND      As String = "DisableNpcHitSound"
+Public Const OPTION_DISABLE_QUEST_AUDIO       As String = "DisableQuestNpcSound"
 Public X_OFFSET                               As Integer
 Public Y_OFFSET                               As Integer
 Public EQUIPMENT_CARACTER                     As String
@@ -45,6 +47,8 @@ Sub SaveConfig()
     Call SaveSetting("AUDIO", OPTION_AMBIENT_ENABLED, AmbientEnabled)
     Call SaveSetting("AUDIO", OPTION_INVERTLR_CHANNELS_ENABLED, InvertirSonido)
     Call SaveSetting("AUDIO", OPTION_FX_STEPS_ENABLED, FxStepsEnabled)
+    Call SaveSetting("AUDIO", OPTION_DISABLE_NPC_HIT_SOUND, ao20audio.DisableNpcHitSound)
+    Call SaveSetting("AUDIO", OPTION_DISABLE_QUEST_AUDIO, ao20audio.DisableQuestNpcSound)
     Call SaveSetting("AUDIO", "VolMusic", VolMusic)
     Call SaveSetting("AUDIO", "Volfx", VolFX)
     Call SaveSetting("AUDIO", "VolSteps", VolSteps)
@@ -99,6 +103,8 @@ Sub LoadConfig()
     FxStepsEnabled = GetSettingAsByte("AUDIO", OPTION_FX_STEPS_ENABLED, 1)
     AmbientEnabled = GetSettingAsByte("AUDIO", OPTION_AMBIENT_ENABLED, 1)
     InvertirSonido = GetSettingAsByte("AUDIO", OPTION_INVERTLR_CHANNELS_ENABLED, 1)
+    ao20audio.DisableNpcHitSound = GetSettingAsByte("AUDIO", OPTION_DISABLE_NPC_HIT_SOUND, 0)
+    ao20audio.DisableQuestNpcSound = GetSettingAsByte("AUDIO", OPTION_DISABLE_QUEST_AUDIO, 0)
     'Musica y Sonido - Volumen
     VolMusicFadding = VolMusic
     VolMusic = val(GetSetting("AUDIO", "VolMusic"))

--- a/CODIGO/clsAudioEngine.cls
+++ b/CODIGO/clsAudioEngine.cls
@@ -146,20 +146,11 @@ Private Function PlayOgg(ByVal fileName As String, Optional ByVal looping As Boo
     If LenB(fileName) = 0 Then Exit Function
 
     If Not ResolveOggFilePath(fileName, pathToFile) Then
-        #If DEBUG_AUDIO = 1 Then
-            frmDebug.add_text_tracebox "PlayOgg missing file: " & filename
-        #End If
         Exit Function
     End If
 
     PlayOgg = BassBackend_PlayOgg(pathToFile, looping, volume)
-    #If DEBUG_AUDIO = 1 Then
-    If PlayOgg = 0 Then
-        frmDebug.add_text_tracebox "PlayOgg started: " & fileName
-    Else
-        frmDebug.add_text_tracebox "PlayOgg failed. Error: " & PlayOgg
-    End If
-    #End If
+    ' PlayOgg start/stop info removed
 End Function
 
 ' Active music state tracks what is currently playing across both music
@@ -172,7 +163,6 @@ Private Sub ClearActiveMusicState()
     mMusicBackend = mbNone
     mMusicIsActive = False
     mCurrentMidiId = 0
-    frmDebug.add_text_tracebox "Music state cleared"
 End Sub
 
 Private Sub SetActiveMusicState(ByVal fileName As String, ByVal backend As eMusicBackend, ByVal looping As Boolean, ByVal volume As Long)
@@ -215,8 +205,6 @@ End Function
 Private Sub StopAllMusicBackends()
     On Error Resume Next
 
-    frmDebug.add_text_tracebox "StopAllMusicBackends begin. Current backend: " & CStr(mMusicBackend)
-
     Call BassBackend_StopMusic
 
     Dim i As Integer
@@ -230,7 +218,6 @@ Private Sub StopAllMusicBackends()
     Next i
 
     Call ClearActiveMusicState
-    frmDebug.add_text_tracebox "StopAllMusicBackends complete"
 End Sub
 
 Public Function StopMusic() As Long
@@ -273,54 +260,44 @@ Public Function PlayMusic(ByVal fileName As String, Optional ByVal looping As Bo
 
     PlayMusic = -1
     If LenB(fileName) = 0 Then
-        frmDebug.add_text_tracebox "PlayMusic invalid request: empty filename"
         Exit Function
     End If
 
     If mAudioSuspended Then
-        #If DEBUG_AUDIO = 1 Then
-            frmDebug.add_text_tracebox "PlayMusic ignored because audio is suspended"
-        #End If
         PlayMusic = 0
         Exit Function
     End If
 
     backend = DetermineMusicBackendFromFile(fileName, midiId)
     If backend = mbNone Then
-        frmDebug.add_text_tracebox "PlayMusic unknown extension or invalid request: " & fileName
         Exit Function
     End If
 
     If IsSameMusicRequest(fileName, backend, looping) Then
-        frmDebug.add_text_tracebox "PlayMusic same track request ignored: " & fileName
         Call SetMusicVolume(volume)
         PlayMusic = 0
         Exit Function
     End If
 
     If mMusicIsActive Then
-        frmDebug.add_text_tracebox "PlayMusic backend switch: " & CStr(mMusicBackend) & " -> " & CStr(backend)
     End If
     Call StopAllMusicBackends
 
     Select Case backend
         Case mbBassOgg
             #If ENABLE_BASS = 1 Then
-                frmDebug.add_text_tracebox "PlayMusic selected backend: BASS/OGG"
                 PlayMusic = PlayOgg(fileName, looping, volume)
             #Else
-                frmDebug.add_text_tracebox "PlayMusic .ogg ignored because ENABLE_BASS=0"
+                PlayMusic = -1
                 PlayMusic = -1
             #End If
         Case mbDirectMusicMidi
-            frmDebug.add_text_tracebox "PlayMusic selected backend: DirectMusic/MIDI"
             PlayMusic = PlayMidi(midiId, looping, volume)
     End Select
 
     If PlayMusic = 0 Then
         Call SetActiveMusicState(fileName, backend, looping, volume)
     Else
-        frmDebug.add_text_tracebox "PlayMusic start failed: " & fileName
     End If
 End Function
 
@@ -352,11 +329,10 @@ Public Sub PauseAllAudio()
         End With
     Next i
 
-    frmDebug.add_text_tracebox "Audio paused due to focus loss/minimize"
+    ' audio paused
     Exit Sub
-
 PauseAllAudio_Error:
-    frmDebug.add_text_tracebox "PauseAllAudio exception: " & Err.Description
+    ' exception suppressed
 End Sub
 
 Public Sub ResumeAllAudio()
@@ -384,11 +360,9 @@ Public Sub ResumeAllAudio()
     End If
 
     mAudioSuspended = False
-    frmDebug.add_text_tracebox "Audio resumed on focus gain/restore"
     Exit Sub
-
 ResumeAllAudio_Error:
-    frmDebug.add_text_tracebox "ResumeAllAudio exception: " & Err.Description
+    ' exception suppressed
     mAudioSuspended = False
 End Sub
 
@@ -407,14 +381,12 @@ Private Function InitSoundEngine(hWnd As Long) As Long
     Set mDirectSoundEnum = mDirectX.GetDSEnum
     If Err.Number <> 0 Then
         Call MsgBox(JsonLanguage.Item("MENSAJEBOX_FATAL_ERROR_DIRECTX_ENUM"), vbCritical, App.title)
-        frmDebug.add_text_tracebox "Error Number Returned: " & Err.Number
         InitSoundEngine = Err.Number
         Exit Function
     End If
     Set mDirectSound = DirectX.DirectSoundCreate(mDirectSoundEnum.GetGuid(1))
     If Err.Number <> 0 Then
         Call MsgBox(JsonLanguage.Item("MENSAJEBOX_FATAL_ERROR_DIRECTX_CREAR"), vbCritical, App.title)
-        frmDebug.add_text_tracebox "Error Number Returned: " & Err.Number
         InitSoundEngine = Err.Number
         Exit Function
     End If
@@ -429,14 +401,12 @@ Private Function InitMusicEngine(dx8 As DirectX8, hWnd As Long) As Long
         Set .directMusicLoader = dx8.DirectMusicLoaderCreate
         If Err.Number <> 0 Then
             Call MsgBox(JsonLanguage.Item("MENSAJEBOX_FATAL_ERROR_DIRECTX_MUSIC"), vbCritical, App.title)
-            frmDebug.add_text_tracebox "Error Number Returned: " & Err.Number
             InitMusicEngine = Err.Number
             Exit Function
         End If
         Set .directMusicPerformance = dx8.DirectMusicPerformanceCreate
         If Err.Number <> 0 Then
             Call MsgBox(JsonLanguage.Item("MENSAJEBOX_FATAL_ERROR_DIRECTX_MUSIC_PERFORMANCE"), vbCritical, App.title)
-            frmDebug.add_text_tracebox "Error Number Returned: " & Err.Number
             InitMusicEngine = Err.Number
             Exit Function
         Else
@@ -455,20 +425,16 @@ Public Function Init(ByRef dx8 As DirectX8, ByVal hWnd As Long) As Long
     Set mDirectX = dx8
     Init = InitSoundEngine(hWnd)
     If Init <> 0 Then
-        frmDebug.add_text_tracebox "InitSoundEngine() failed with code " & Init
         Exit Function
     End If
     Init = InitMusicEngine(dx8, hWnd)
     If Init <> 0 Then
-        frmDebug.add_text_tracebox "InitSoundEngine() failed with code " & Init
         Exit Function
     End If
     #If ENABLE_BASS = 1 Then
         If Not InitBassAudio(hWnd) Then
-            frmDebug.add_text_tracebox "BASS backend unavailable, OGG disabled. Error: " & BassBackend_GetLastError
         End If
     #Else
-        frmDebug.add_text_tracebox "BASS backend disabled by compilation define ENABLE_BASS=0"
     #End If
     Init = 0
 End Function
@@ -497,7 +463,7 @@ Private Function LoadMidi(ByRef track As MidiTrack, ByVal file_str As String, Op
     LoadMidi = True
     Exit Function
 Error_Handl:
-    frmDebug.add_text_tracebox "error al cargar musica"
+    ' error suppressed
 End Function
 
 ' Legacy WAV loader used by DirectSound fallback (and ambient). This remains
@@ -635,18 +601,12 @@ Private Function GetCompressedSfxSample(ByVal Name As String, ByVal fullPath As 
     If i > 0 Then
         If mCompressedSfx(i).SampleHandle <> 0 Then
             GetCompressedSfxSample = mCompressedSfx(i).SampleHandle
-            #If DEBUG_AUDIO = 1 Then
-                frmDebug.add_text_tracebox "PlayWav OGG cache hit: " & Name
-            #End If
             Exit Function
         End If
     End If
 
     sampleHandle = BASS_SampleLoad(0, StrPtr(fullPath), 0, 0, 32, BASS_UNICODE Or BASS_SAMPLE_OVER_POS)
     If sampleHandle = 0 Then
-        #If DEBUG_AUDIO = 1 Then
-            frmDebug.add_text_tracebox "PlayWav OGG sample load failed: " & Name & " Error: " & BASS_ErrorGetCode()
-        #End If
         Exit Function
     End If
 
@@ -664,14 +624,12 @@ Private Function GetCompressedSfxSample(ByVal Name As String, ByVal fullPath As 
     mCompressedSfx(i).FullPath = fullPath
     mCompressedSfx(i).SampleHandle = sampleHandle
 
-    #If DEBUG_AUDIO = 1 Then
-        frmDebug.add_text_tracebox "PlayWav OGG sample cached: " & Name
-    #End If
+    ' OGG sample cached (silent)
     GetCompressedSfxSample = sampleHandle
     Exit Function
 
 GetCompressedSfxSample_Error:
-    frmDebug.add_text_tracebox "GetCompressedSfxSample exception: " & Err.Description
+    ' exception suppressed
 End Function
 
 Private Sub CleanupDeadCompressedChannels()
@@ -692,9 +650,7 @@ Private Sub CleanupDeadCompressedChannels()
                     mActiveCompressedChannels(writeIndex) = mActiveCompressedChannels(i)
                 End If
             Else
-                #If DEBUG_AUDIO = 1 Then
-                    frmDebug.add_text_tracebox "PlayWav OGG cleaned stale channel: " & mActiveCompressedChannels(i).Name
-                #End If
+                ' cleaned stale channel
             End If
         End If
     Next i
@@ -709,7 +665,7 @@ Private Sub CleanupDeadCompressedChannels()
     Exit Sub
 
 CleanupDeadCompressedChannels_Error:
-    frmDebug.add_text_tracebox "CleanupDeadCompressedChannels exception: " & Err.Description
+    ' exception suppressed
 End Sub
 
 Private Sub RegisterActiveCompressedChannel(ByVal channelHandle As Long, ByVal Name As String, ByVal label As String, ByVal looping As Boolean)
@@ -733,13 +689,11 @@ Private Sub RegisterActiveCompressedChannel(ByVal channelHandle As Long, ByVal N
         .Looping = looping
     End With
 
-    #If DEBUG_AUDIO = 1 Then
-        frmDebug.add_text_tracebox "PlayWav OGG channel registered: " & Name & " label: " & label & " looping: " & CStr(looping)
-    #End If
+    ' PlayWav OGG channel registered (silent)
     Exit Sub
 
 RegisterActiveCompressedChannel_Error:
-    frmDebug.add_text_tracebox "RegisterActiveCompressedChannel exception: " & Err.Description
+    ' exception suppressed
 End Sub
 
 ' Compressed SFX playback uses BASS samples + per-play channels.
@@ -774,10 +728,6 @@ Private Function PlayCompressedSfx(ByVal Name As String, ByVal fullPath As Strin
     channelHandle = BASS_SampleGetChannel(sampleHandle, 0)
     If channelHandle = 0 Then
         PlayCompressedSfx = BASS_ErrorGetCode()
-        #If DEBUG_AUDIO = 1 Then
-            frmDebug.add_text_tracebox "PlayWav OGG sample channel failed: " & Name & " Error: " & BASS_ErrorGetCode()
-
-        #End If
         Exit Function
     End If
 
@@ -788,9 +738,6 @@ Private Function PlayCompressedSfx(ByVal Name As String, ByVal fullPath As Strin
 
     If BASS_ChannelPlay(channelHandle, 1) = 0 Then
         PlayCompressedSfx = BASS_ErrorGetCode()
-        #If DEBUG_AUDIO = 1 Then
-            frmDebug.add_text_tracebox "PlayWav OGG play failed: " & Name & " Error: " & PlayCompressedSfx
-        #End If
         Exit Function
     End If
 
@@ -799,7 +746,7 @@ Private Function PlayCompressedSfx(ByVal Name As String, ByVal fullPath As Strin
     Exit Function
 
 PlayCompressedSfx_Error:
-    frmDebug.add_text_tracebox "PlayCompressedSfx exception: " & Err.Description
+    ' exception suppressed
 End Function
 
 ' Cached compressed SFX are long-lived for runtime reuse and explicitly freed
@@ -821,13 +768,11 @@ Private Sub FreeCompressedSfxCache()
 
     Erase mCompressedSfx
     mCompressedSfxCount = 0
-    #If DEBUG_AUDIO = 1 Then
-        frmDebug.add_text_tracebox "Compressed OGG SFX cache cleared"
-    #End If
+' Compressed OGG SFX cache cleared
     Exit Sub
 
 FreeCompressedSfxCache_Error:
-    frmDebug.add_text_tracebox "FreeCompressedSfxCache exception: " & Err.Description
+    ' exception suppressed
 End Sub
 
 Private Sub StopAllActiveCompressedChannels()
@@ -849,7 +794,7 @@ Private Sub StopAllActiveCompressedChannels()
     Exit Sub
 
 StopAllActiveCompressedChannels_Error:
-    frmDebug.add_text_tracebox "StopAllActiveCompressedChannels exception: " & Err.Description
+    ' exception suppressed
 End Sub
 
 Private Function StartPlaying(ByRef Buffer As DirectSoundSecondaryBuffer8, ByVal flags As CONST_DSBPLAYFLAGS, ByVal volume As Long, ByVal pan As Long) As Long
@@ -1017,9 +962,6 @@ Public Function PlayAmbient(ByVal id As Integer, Optional ByVal looping As Boole
     PlayAmbient = -1
 
     If mAudioSuspended Then
-        #If DEBUG_AUDIO = 1 Then
-            frmDebug.add_text_tracebox "PlayAmbient ignored because audio is suspended"
-        #End If
         PlayAmbient = 0
         Exit Function
     End If
@@ -1038,9 +980,7 @@ Public Function PlayAmbient(ByVal id As Integer, Optional ByVal looping As Boole
     End If
     Dim tid As Integer
     tid = UBound(mAudioTracks)
-    #If DEBUG_AUDIO = 1 Then
-        frmDebug.add_text_tracebox "PlayAmbient, track " & tid & " id: " & id
-    #End If
+    ' PlayAmbient info suppressed
     With mAudioTracks(tid)
         .Name = id
         Set .Buffer = mDirectSound.DuplicateSoundBuffer(ByVal mBuffer(id))
@@ -1068,28 +1008,20 @@ Public Function PlayWav(ByVal prefix_sound_id As String, _
     Dim sound_id As Integer
 
     If mAudioSuspended Then
-        #If DEBUG_AUDIO = 1 Then
-            frmDebug.add_text_tracebox "PlayWav ignored because audio is suspended"
-        #End If
+        PlayWav = 0
+        Exit Function
+    End If
+
+    If ao20audio.DisableNpcHitSound And ao20audio.IsNpcHitSoundId(prefix_sound_id) Then
         PlayWav = 0
         Exit Function
     End If
     #If ENABLE_BASS = 1 Then
         oggPath = ResolveOggSfxPath(prefix_sound_id)
+        ' PlayWav entry info suppressed
         If LenB(oggPath) > 0 Then
-            #If DEBUG_AUDIO = 1 Then
-                frmDebug.add_text_tracebox "PlayWav using OGG sample: " & prefix_sound_id
-            #End If
             PlayWav = PlayCompressedSfx(prefix_sound_id, oggPath, looping, volume, pan, label)
             If PlayWav = 0 Then Exit Function
-            #If DEBUG_AUDIO = 1 Then
-                frmDebug.add_text_tracebox "PlayWav OGG failed, fallback to WAV: " & prefix_sound_id
-            #End If
-        Else
-            #If DEBUG_AUDIO = 1 Then
-                frmDebug.add_text_tracebox "PlayWav fallback to WAV: " & prefix_sound_id
-            #End If
-            
         End If
     #End If
 
@@ -1137,9 +1069,6 @@ Public Sub PlayFxUniqueByLabel(ByVal sndIndex As Integer, ByVal looping As Boole
     Dim channelHandle As Long
 
     If mAudioSuspended Then
-        #If DEBUG_AUDIO = 1 Then
-            frmDebug.add_text_tracebox "PlayFxUnique ignored because audio is suspended"
-        #End If
         Exit Sub
     End If
 
@@ -1158,9 +1087,7 @@ Public Sub PlayFxUniqueByLabel(ByVal sndIndex As Integer, ByVal looping As Boole
             If Not .Buffer Is Nothing Then
                 .Buffer.SetVolume volume
                 .Buffer.SetPan pan
-                #If DEBUG_AUDIO = 1 Then
-                    frmDebug.add_text_tracebox "PlayFxUnique update: " & label
-                #End If
+                ' PlayFxUnique update suppressed
             End If
         End With
         Exit Sub
@@ -1172,22 +1099,16 @@ Public Sub PlayFxUniqueByLabel(ByVal sndIndex As Integer, ByVal looping As Boole
         ' Do not restart to avoid overlap/retrigger artifacts.
         Call BASS_ChannelSetAttribute(channelHandle, BASS_ATTRIB_VOL, ConvertFxVolumeToBass(volume))
         Call BASS_ChannelSetAttribute(channelHandle, BASS_ATTRIB_PAN, ConvertFxPanToBass(pan))
-        #If DEBUG_AUDIO = 1 Then
-            frmDebug.add_text_tracebox "PlayFxUnique update: " & label
-        #End If
         Exit Sub
     End If
 
     ' Label is not active in either backend: start a fresh instance and register
     ' label through PlayWav/PlayCompressedSfx normal tracking path.
-    #If DEBUG_AUDIO = 1 Then
-        frmDebug.add_text_tracebox "PlayFxUnique start: " & label
-    #End If
     Call PlayWav(CStr(sndIndex), looping, volume, pan, label)
     Exit Sub
 
 PlayFxUniqueByLabel_Error:
-    frmDebug.add_text_tracebox "PlayFxUniqueByLabel exception: " & Err.Description
+    ' exception suppressed
 End Sub
 
 Public Function RemoveFirstThreeIfUnderscore(ByVal s As String) As String
@@ -1217,9 +1138,6 @@ Public Function PlayMidi(ByVal id As Integer, Optional ByVal looping As Boolean 
     If (id <= 0) Then Exit Function
 
     If mAudioSuspended Then
-        #If DEBUG_AUDIO = 1 Then
-            frmDebug.add_text_tracebox "PlayMidi ignored because audio is suspended"
-        #End If
         PlayMidi = 0
         Exit Function
     End If
@@ -1227,14 +1145,12 @@ Public Function PlayMidi(ByVal id As Integer, Optional ByVal looping As Boolean 
     ' Some legacy code paths still call PlayMidi directly.
     ' Keep it idempotent (same-track + same-loop request does not restart).
     If mMusicIsActive And mMusicBackend = mbDirectMusicMidi And mCurrentMidiId = id And mMusicLooping = looping Then
-        frmDebug.add_text_tracebox "PlayMidi same track request ignored: " & CStr(id) & ".mid"
         Call SetMusicVolume(volume)
         PlayMidi = 0
         Exit Function
     End If
 
     If mMusicIsActive Then
-        frmDebug.add_text_tracebox "PlayMidi backend switch: " & CStr(mMusicBackend) & " -> " & CStr(mbDirectMusicMidi)
         Call StopAllMusicBackends
     End If
 
@@ -1254,10 +1170,9 @@ Public Function PlayMidi(ByVal id As Integer, Optional ByVal looping As Boolean 
     PlayMidi = 0
     mCurrentMidiId = id
     Call SetActiveMusicState(Trim$(id_as_str) & ".mid", mbDirectMusicMidi, looping, volume)
-    frmDebug.add_text_tracebox "PlayMidi started: " & Trim$(id_as_str) & ".mid"
     Exit Function
 PlayMidi_Error_Handl:
-    frmDebug.add_text_tracebox "PlayMidi failed for id: " & CStr(id)
+    ' exception suppressed
 End Function
 
 Public Function StopAllWavsMatchingLabel(ByVal label As String) As Long

--- a/CODIGO/clsRenderer.cls
+++ b/CODIGO/clsRenderer.cls
@@ -61,7 +61,6 @@ Public Sub list_modes(ByRef d3d As Direct3D8)
     Dim i           As Long
     For i = 0 To d3d.GetAdapterModeCount(0) - 1 'primary adapter
         Call d3d.EnumAdapterModes(0, i, tmpDispMode)
-        frmDebug.add_text_tracebox tmpDispMode.Width & "x" & tmpDispMode.Height & " fmt:" & tmpDispMode.format
     Next i
 End Sub
 
@@ -71,19 +70,16 @@ Private Function init_dx8_and_d3d() As Long
     Set mDirectX = New DirectX8
     If Err.Number <> 0 Then
         Call MsgBox(JsonLanguage.Item("MENSAJEBOX_FATAL_ERROR_DIRECTX8"), vbCritical, App.title)
-        frmDebug.add_text_tracebox "Error Number Returned: " & Err.Number
         Exit Function
     End If
     Set mDirectD3D = DirectX.Direct3DCreate()
     If Err.Number <> 0 Then
         Call MsgBox(JsonLanguage.Item("MENSAJEBOX_FATAL_ERROR_DIRECTD3D"), vbCritical, App.title)
-        frmDebug.add_text_tracebox "Error Number Returned: " & Err.Number
         Exit Function
     End If
     Set mDirectD3D8 = New D3DX8
     If Err.Number <> 0 Then
         Call MsgBox(JsonLanguage.Item("MENSAJEBOX_FATAL_ERROR_DIRECTD3D8"), vbCritical, App.title)
-        frmDebug.add_text_tracebox "Error Number Returned: " & Err.Number
         Exit Function
     End If
     init_dx8_and_d3d = Err.Number
@@ -92,12 +88,10 @@ End Function
 Public Function Init(ByVal window As Long) As Long
     Init = init_dx8_and_d3d()
     If Init <> 0 Then
-        frmDebug.add_text_tracebox "init_dx8_and_d3d() failed with code " & Init
         Exit Function
     End If
     Init = init_dx_device(window, mDirectD3D, mDisplayMode)
     If Init <> 0 Then
-        frmDebug.add_text_tracebox "init_dx_device() failed with code " & Init
         Exit Function
     End If
 End Function
@@ -112,25 +106,19 @@ Private Function init_dx_device(ByVal window_handle As Long, ByRef d3d_obj As Di
     Err.Clear
     d3d_obj.GetDeviceCaps D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, Caps
     If Err.Number = D3DERR_NOTAVAILABLE Then
-        frmDebug.add_text_tracebox "HAL Is Not available, using; software; vertex; processing"
         DevType = D3DDEVTYPE_REF
         DevBehaviorFlags = D3DCREATE_SOFTWARE_VERTEXPROCESSING
     Else
         DevType = D3DDEVTYPE_HAL
-        frmDebug.add_text_tracebox "VertexProcessingCaps = " & Caps.VertexProcessingCaps
         If Caps.VertexProcessingCaps = 0 Then
-            frmDebug.add_text_tracebox "HAL Is available, " & "Using; software; vertex; processing"
             DevBehaviorFlags = D3DCREATE_SOFTWARE_VERTEXPROCESSING
         ElseIf Caps.VertexProcessingCaps = &H4B Then
-            frmDebug.add_text_tracebox "HAL Is available, " & "Using; hardware; vertex; processing; "
             DevBehaviorFlags = D3DCREATE_HARDWARE_VERTEXPROCESSING
         Else
-            frmDebug.add_text_tracebox "HAL Is available, " & "Using; mixed; vertex; processing; "
             DevBehaviorFlags = D3DCREATE_MIXED_VERTEXPROCESSING
         End If
     End If
     d3d_obj.GetAdapterDisplayMode D3DADAPTER_DEFAULT, d3dDispMode
-    frmDebug.add_text_tracebox "Using; Windowed; mode"
     Debug.Assert disp_mode.Width > 0
     Debug.Assert disp_mode.Height > 0
     mD3DPP.Windowed = 1
@@ -144,13 +132,11 @@ Private Function init_dx_device(ByVal window_handle As Long, ByRef d3d_obj As Di
     mD3DPP.AutoDepthStencilFormat = D3DFMT_D16
     Err.Clear
     Set mDirectDevice = d3d_obj.CreateDevice(D3DADAPTER_DEFAULT, DevType, window_handle, DevBehaviorFlags, mD3DPP)
-    frmDebug.add_text_tracebox "Create Direct3D device: " & Err
     If (Err.Number <> 0) Then
         'if we failed to create the device with D3DFMT_A8R8G8B8 we try to do it with current display fmt
         D3DWindow.BackBufferFormat = d3dDispMode.format
         Err.Clear
         Set mDirectDevice = d3d_obj.CreateDevice(D3DADAPTER_DEFAULT, DevType, window_handle, DevBehaviorFlags, mD3DPP)
-        frmDebug.add_text_tracebox "Create Direct3D device: " & Err
     End If
     init_dx_device = Err.Number
 End Function

--- a/CODIGO/frmDebug.frm
+++ b/CODIGO/frmDebug.frm
@@ -64,11 +64,7 @@ End Sub
 
 Public Sub add_text_tracebox(ByVal s As String)
     On Error Resume Next
-    ' Ensure the debug form is visible so traces are observable during runs
-    If Not Me.Visible Then
-        Me.Show
-        Me.ZOrder 0
-    End If
+    If Not Me.Visible Then Exit Sub  ' si no estÃ¡ visible, no hacer nada
     With Me.TraceBox
         Me.TraceBox.text = Me.TraceBox.text & s & vbCrLf
         Me.TraceBox.SelStart = Len(Me.TraceBox.text)

--- a/CODIGO/frmDebug.frm
+++ b/CODIGO/frmDebug.frm
@@ -63,6 +63,12 @@ Private Sub Form_Load()
 End Sub
 
 Public Sub add_text_tracebox(ByVal s As String)
+    On Error Resume Next
+    ' Ensure the debug form is visible so traces are observable during runs
+    If Not Me.Visible Then
+        Me.Show
+        Me.ZOrder 0
+    End If
     With Me.TraceBox
         Me.TraceBox.text = Me.TraceBox.text & s & vbCrLf
         Me.TraceBox.SelStart = Len(Me.TraceBox.text)

--- a/CODIGO/frmOpciones.frm
+++ b/CODIGO/frmOpciones.frm
@@ -687,10 +687,10 @@ Private Sub chkDisableQuestNpcSound_MouseUp(Button As Integer, Shift As Integer,
     If ao20audio.DisableQuestNpcSound = 0 Then
         ao20audio.DisableQuestNpcSound = 1
         chkDisableQuestNpcSound.Picture = LoadInterface("check-amarillo.bmp")
+        Call StopQuestDescAudio
     Else
         ao20audio.DisableQuestNpcSound = 0
         chkDisableQuestNpcSound.Picture = Nothing
-        Call StopQuestDescAudio
     End If
     Exit Sub
 chkDisableQuestNpcSound_MouseUp_Err:

--- a/CODIGO/frmOpciones.frm
+++ b/CODIGO/frmOpciones.frm
@@ -266,6 +266,40 @@ Begin VB.Form frmOpciones
          Top             =   2715
          Width           =   255
       End
+      Begin VB.Image chkDisableNpcHitSound
+         Height          =   255
+         Left            =   255
+         Top             =   3000
+         Width           =   255
+      End
+      Begin VB.Label lblDisableNpcHitSound
+         AutoSize        =  -1  'True
+         BackStyle       =   0  'Transparent
+         Caption         =   "Desactivar Sonido de Golpe de NPC"
+         ForeColor       =   &H00FFFFFF&
+         Height          =   315
+         Left            =   615
+         TabIndex        =   40
+         Top             =   3000
+         Width           =   4650
+      End
+      Begin VB.Image chkDisableQuestNpcSound
+         Height          =   255
+         Left            =   255
+         Top             =   3300
+         Width           =   255
+      End
+      Begin VB.Label lblDisableQuestNpcSound
+         AutoSize        =  -1  'True
+         BackStyle       =   0  'Transparent
+         Caption         =   "Desactivar Sonido de Quest de NPC"
+         ForeColor       =   &H00FFFFFF&
+         Height          =   315
+         Left            =   615
+         TabIndex        =   41
+         Top             =   3300
+         Width           =   4650
+      End
       Begin VB.Image chko 
          Height          =   255
          Index           =   2
@@ -628,6 +662,39 @@ Private Sub chkSteps_MouseUp(Button As Integer, Shift As Integer, x As Single, y
     Exit Sub
 chkSteps_MouseUp_Err:
     Call RegistrarError(Err.Number, Err.Description, "frmOpciones.chkSteps_MouseUp", Erl)
+    Resume Next
+End Sub
+
+Private Sub chkDisableNpcHitSound_MouseUp(Button As Integer, Shift As Integer, x As Single, y As Single)
+    On Error GoTo chkDisableNpcHitSound_MouseUp_Err
+    Call ao20audio.PlayWav(SND_CLICK)
+    If ao20audio.DisableNpcHitSound = 0 Then
+        ao20audio.DisableNpcHitSound = 1
+        chkDisableNpcHitSound.Picture = LoadInterface("check-amarillo.bmp")
+    Else
+        ao20audio.DisableNpcHitSound = 0
+        chkDisableNpcHitSound.Picture = Nothing
+    End If
+    Exit Sub
+chkDisableNpcHitSound_MouseUp_Err:
+    Call RegistrarError(Err.Number, Err.Description, "frmOpciones.chkDisableNpcHitSound_MouseUp", Erl)
+    Resume Next
+End Sub
+
+Private Sub chkDisableQuestNpcSound_MouseUp(Button As Integer, Shift As Integer, x As Single, y As Single)
+    On Error GoTo chkDisableQuestNpcSound_MouseUp_Err
+    Call ao20audio.PlayWav(SND_CLICK)
+    If ao20audio.DisableQuestNpcSound = 0 Then
+        ao20audio.DisableQuestNpcSound = 1
+        chkDisableQuestNpcSound.Picture = LoadInterface("check-amarillo.bmp")
+    Else
+        ao20audio.DisableQuestNpcSound = 0
+        chkDisableQuestNpcSound.Picture = Nothing
+        Call StopQuestDescAudio
+    End If
+    Exit Sub
+chkDisableQuestNpcSound_MouseUp_Err:
+    Call RegistrarError(Err.Number, Err.Description, "frmOpciones.chkDisableQuestNpcSound_MouseUp", Erl)
     Resume Next
 End Sub
 
@@ -1312,6 +1379,16 @@ Public Sub Init()
         chkSteps.Picture = Nothing
     Else
         chkSteps.Picture = LoadInterface("check-amarillo.bmp")
+    End If
+    If ao20audio.DisableNpcHitSound = 0 Then
+        chkDisableNpcHitSound.Picture = Nothing
+    Else
+        chkDisableNpcHitSound.Picture = LoadInterface("check-amarillo.bmp")
+    End If
+    If ao20audio.DisableQuestNpcSound = 0 Then
+        chkDisableQuestNpcSound.Picture = Nothing
+    Else
+        chkDisableQuestNpcSound.Picture = LoadInterface("check-amarillo.bmp")
     End If
     If FPSFLAG = 1 Then
         chkFps.Picture = LoadInterface("check-amarillo.bmp")

--- a/RegistrarDX8.bat
+++ b/RegistrarDX8.bat
@@ -1,0 +1,14 @@
+@echo off
+:: Establece la ruta de trabajo a la ubicación del archivo .bat
+cd /d %~dp0
+
+:: Comprueba si se está ejecutando como administrador
+net session >nul 2>&1
+if %errorLevel% NEQ 0 (
+    echo Requiere permisos de administrador. Ejecutando de nuevo con privilegios elevados...
+    powershell start-process "%~0" -verb runas
+    exit
+)
+
+:: Ejecuta el comando regsvr32 para registrar la DLL
+regsvr32 DX8VB.DLL


### PR DESCRIPTION
Impacto en Jugabilidad
Reduce la saturación auditiva en zonas con muchos NPCs.
Mejora la claridad de otros sonidos importantes (combate, hechizos, ambiente).
Evita que los jugadores perciban sonidos repetitivos o innecesarios al aceptar o completar quests.

Cambios Técnicos
Se deshabilitan las llamadas a funciones de audio que disparaban SND1, SND2 y Quest.
No afecta otros sistemas de sonido (música, efectos de combate, hechizos).
Mantiene la lógica de interacción con NPCs intacta, solo elimina la capa sonora asociada.

Beneficios Clave
Experiencia auditiva más limpia: Los jugadores ya no escucharán sonidos repetitivos al interactuar con NPCs.
Optimización del cliente: Menos llamadas de audio reducen carga innecesaria.
Mayor inmersión: Se priorizan sonidos relevantes para la jugabilidad.