### PR TITLE
Caras de NPCs

### DIFF
--- a/CODIGO/ModUtils.bas
+++ b/CODIGO/ModUtils.bas
@@ -282,6 +282,7 @@ Public Type NpcDatas
     Amphibian As Boolean
     QuizaProb As Integer
     DisabledInBattleServer As Integer
+    NpcFaceGrh As Long
 End Type
 
 Public Type HechizoDatas

--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -1619,18 +1619,33 @@ Private Sub HandleChatOverHeadImpl(ByVal chat As String, _
             chat = NpcData(text).desc
             copiar = False
             If npcs_en_render And tutorial_index <= 0 Then
-                Dim headGrh As Long
-                Dim bodyGrh As Long
-                headGrh = HeadData(NpcData(text).Head).Head(3).GrhIndex
-                bodyGrh = GrhData(BodyData(NpcData(text).Body).Walk(3).GrhIndex).Frames(1)
-                If headGrh = 0 Then
-                    Call mostrarCartel(Split(NpcData(text).Name, " <")(0), NpcData(text).desc, bodyGrh, 200 + 30 * Len(chat), &H164B8A, , , True, 100, 479, 100, 535, 20, 500, _
-                            50, 80, bodyGrh, 1)
+                Dim npcFaceGrh As Long
+                Dim useNpcFaceGrh As Boolean
+                npcFaceGrh = NpcData(text).NpcFaceGrh
+                If npcFaceGrh > 0 Then
+                    If npcFaceGrh <= MaxGrh Then
+                        useNpcFaceGrh = GrhData(npcFaceGrh).NumFrames > 0 And _
+                                GrhData(npcFaceGrh).pixelWidth > 0 And _
+                                GrhData(npcFaceGrh).pixelHeight > 0
+                    End If
+                End If
+                If useNpcFaceGrh Then
+                    Call mostrarCartel(Split(NpcData(text).Name, " <")(0), NpcData(text).desc, npcFaceGrh, 200 + 30 * Len(chat), &H164B8A, , , True, 145, 479, 145, 535, 5, 477, _
+                            GrhData(npcFaceGrh).pixelWidth, GrhData(npcFaceGrh).pixelHeight)
                 Else
-                    Dim HeadOffsetY As Integer
-                    HeadOffsetY = CInt(BodyData(NpcData(text).Body).HeadOffset.y) - 30
-                    Call mostrarCartel(Split(NpcData(text).Name, " <")(0), NpcData(text).desc, headGrh, 200 + 30 * Len(chat), &H164B8A, , , True, 100, 479, 100, 535, 20, 500, _
-                            50, 100, bodyGrh, HeadOffsetY)
+                    Dim headGrh As Long
+                    Dim bodyGrh As Long
+                    headGrh = HeadData(NpcData(text).Head).Head(3).GrhIndex
+                    bodyGrh = GrhData(BodyData(NpcData(text).Body).Walk(3).GrhIndex).Frames(1)
+                    If headGrh = 0 Then
+                        Call mostrarCartel(Split(NpcData(text).Name, " <")(0), NpcData(text).desc, bodyGrh, 200 + 30 * Len(chat), &H164B8A, , , True, 100, 479, 100, 535, 20, 500, _
+                                50, 80, bodyGrh, 1)
+                    Else
+                        Dim HeadOffsetY As Integer
+                        HeadOffsetY = CInt(BodyData(NpcData(text).Body).HeadOffset.y) - 30
+                        Call mostrarCartel(Split(NpcData(text).Name, " <")(0), NpcData(text).desc, headGrh, 200 + 30 * Len(chat), &H164B8A, , , True, 100, 479, 100, 535, 20, 500, _
+                                50, 100, bodyGrh, HeadOffsetY)
+                    End If
                 End If
             End If
         Case "PMAG"

--- a/CODIGO/Recursos.bas
+++ b/CODIGO/Recursos.bas
@@ -1388,6 +1388,7 @@ Public Sub CargarIndicesOBJ()
         NpcData(Npc).BodyOnLand = val(Leer.GetValue("npc" & Npc, "Body"))
         NpcData(Npc).BodyIdle = val(Leer.GetValue("npc" & Npc, "BodyIdle"))
         NpcData(Npc).DisabledInBattleServer = val(Leer.GetValue("npc" & Npc, "DisabledInBattleServer"))
+        NpcData(Npc).NpcFaceGrh = val(Leer.GetValue("npc" & Npc, "NpcFaceGrh"))
         NpcData(Npc).Amphibian = val(Leer.GetValue("npc" & Npc, "Amphibian")) > 0
         If NpcData(Npc).DropCount > 0 Then
             ReDim NpcData(Npc).DropObj(1 To NpcData(Npc).DropCount) As Integer


### PR DESCRIPTION
Agregué el campo NpcFaceGrh As Long a la estructura NpcDatas, para que cada NPC pueda definir opcionalmente un GRH de cara/retrato.

Ahora el loader de NPCs lee NpcFaceGrh desde la configuración del NPC; si la clave no existe, queda en 0 y no cambia el comportamiento existente.

Modifiqué el flujo de NPCDESC: si NpcFaceGrh > 0, el cartel muestra solo ese GRH en tamaño 80x80; si no, mantiene el sistema actual con Head + Body.

Commit realizado en la rama actual: d31cef9 Add NPC face GRH support.

<img width="509" height="157" alt="image" src="https://github.com/user-attachments/assets/b31a156f-1f3d-4b18-9f78-44cfeb1b3fb8" />
