### PR TITLE
Add clickable BodyIdle animation for static NPCs

### DIFF
--- a/CODIGO/ModGameplayUI.bas
+++ b/CODIGO/ModGameplayUI.bas
@@ -119,6 +119,7 @@ Public Sub OnClick(ByVal MouseButton As Long, ByVal MouseShift As Long)
         If Not Comerciando Then
             If MouseShift = 0 Then
                 If UsingSkill = 0 Or frmMain.MacroLadder.enabled Then
+                    Call TriggerNpcBodyIdleClick(tX, tY)
                     Call WriteLeftClick(tX, tY)
                 Else
                     Dim SendSkill As Boolean

--- a/CODIGO/ModUtils.bas
+++ b/CODIGO/ModUtils.bas
@@ -256,6 +256,8 @@ Public Type NpcDatas
     Body As Integer
     BodyOnLand As Integer
     BodyIdle As Integer
+    Movement As Byte
+    BodyIdleClickLoops As Byte
     BodyOnWater As Integer
     BodyOnWaterIdle As Integer
     LandAttackAnimation As Integer

--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -2290,6 +2290,8 @@ Private Sub HandleCharacterCreate()
         .AnimAtaque1 = NpcData(.NpcNumber).LandAttackAnimation
         .BodyOnLand = NpcData(.NpcNumber).Body
         .BodyIdle = NpcData(.NpcNumber).BodyIdle
+        .Movement = NpcData(.NpcNumber).Movement
+        .BodyIdleClickLoops = NpcData(.NpcNumber).BodyIdleClickLoops
         .BodyOnWaterIdle = NpcData(.NpcNumber).BodyOnWaterIdle
         .BodyOnWater = NpcData(.NpcNumber).BodyOnWater
         .AnimAtaque2 = NpcData(.NpcNumber).WaterAttackAnimation

--- a/CODIGO/Recursos.bas
+++ b/CODIGO/Recursos.bas
@@ -1388,6 +1388,8 @@ Public Sub CargarIndicesOBJ()
         NpcData(Npc).BodyOnWaterIdle = val(Leer.GetValue("npc" & Npc, "BodyOnWaterIdle"))
         NpcData(Npc).BodyOnLand = val(Leer.GetValue("npc" & Npc, "Body"))
         NpcData(Npc).BodyIdle = val(Leer.GetValue("npc" & Npc, "BodyIdle"))
+        NpcData(Npc).Movement = val(Leer.GetValue("npc" & Npc, "Movement"))
+        NpcData(Npc).BodyIdleClickLoops = val(Leer.GetValue("npc" & Npc, "BodyIdleClickLoops"))
         NpcData(Npc).DisabledInBattleServer = val(Leer.GetValue("npc" & Npc, "DisabledInBattleServer"))
         NpcData(Npc).NpcFaceGrh = val(Leer.GetValue("npc" & Npc, "NpcFaceGrh"))
         NpcData(Npc).Amphibian = val(Leer.GetValue("npc" & Npc, "Amphibian")) > 0

--- a/CODIGO/TileEngine.bas
+++ b/CODIGO/TileEngine.bas
@@ -284,6 +284,10 @@ Public Type Char
     DontBlockTile As Boolean
     BodyOnLand As Integer
     BodyIdle As Integer
+    Movement As Byte
+    BodyIdleClickLoops As Byte
+    IdleClickActive As Boolean
+    IdleClickReturnBody As Integer
     BodyOnWater As Integer
     BodyOnWaterIdle As Integer
     AnimAtaque2 As Integer

--- a/CODIGO/TileEngine_Chars.bas
+++ b/CODIGO/TileEngine_Chars.bas
@@ -70,10 +70,36 @@ Public Sub ResetCharInfo(ByVal charindex As Integer)
         .scrollDirectionY = 0
         .MoveOffsetX = 0
         .MoveOffsetY = 0
+        .IdleClickActive = False
+        .IdleClickReturnBody = 0
     End With
     Exit Sub
 ResetCharInfo_Err:
     Call RegistrarError(Err.Number, Err.Description, "TileEngine_Chars.ResetCharInfo", Erl)
+    Resume Next
+End Sub
+
+Public Sub TriggerNpcBodyIdleClick(ByVal TileX As Byte, ByVal TileY As Byte)
+    On Error GoTo TriggerNpcBodyIdleClick_Err
+    Dim charindex As Integer
+    charindex = MapData(TileX, TileY).charindex
+    If charindex = 0 And TileY < MaxYBorder Then charindex = MapData(TileX, TileY + 1).charindex
+    If charindex <= 0 Then Exit Sub
+    If charindex > UBound(charlist) Then Exit Sub
+    With charlist(charindex)
+        If Not .EsNpc Then Exit Sub
+        If .Movement <> 1 Then Exit Sub
+        If .BodyIdle <= 0 Then Exit Sub
+        If .BodyIdle > UBound(BodyData) Then Exit Sub
+        .IdleClickActive = True
+        .IdleClickReturnBody = IIf(.BodyOnLand > 0, .BodyOnLand, .iBody)
+        .Body = BodyData(.BodyIdle)
+        .Body.Walk(.Heading).Loops = IIf(.BodyIdleClickLoops > 0, .BodyIdleClickLoops - 1, 0)
+        .Body.Walk(.Heading).started = FrameTime
+    End With
+    Exit Sub
+TriggerNpcBodyIdleClick_Err:
+    Call RegistrarError(Err.Number, Err.Description, "TileEngine_Chars.TriggerNpcBodyIdleClick", Erl)
     Resume Next
 End Sub
 

--- a/CODIGO/engine.bas
+++ b/CODIGO/engine.bas
@@ -1337,8 +1337,17 @@ Sub Char_Render(ByVal charindex As Long, ByVal PixelOffsetX As Integer, ByVal Pi
     Dim terrainHeight    As Integer
     With charlist(charindex)
         If .Heading = 0 Then Exit Sub
+        If .IdleClickActive Then
+            If .Body.Walk(.Heading).started = 0 Then
+                .IdleClickActive = False
+                If .IdleClickReturnBody > 0 Then
+                    .Body = BodyData(.IdleClickReturnBody)
+                    .iBody = .IdleClickReturnBody
+                End If
+            End If
+        End If
         ' --- ESTADO IDLE AL COMIENZO DEL FRAME ---
-        If Not .Moving And Not .TranslationActive And .Idle And .scrollDirectionX = 0 And .scrollDirectionY = 0 And .MoveOffsetX = 0 And .MoveOffsetY = 0 Then
+        If Not .IdleClickActive And Not .Moving And Not .TranslationActive And .Idle And .scrollDirectionX = 0 And .scrollDirectionY = 0 And .MoveOffsetX = 0 And .MoveOffsetY = 0 Then
             If .Body.AnimateOnIdle = 0 Then
                 ' Quieto SIN animación: congelar la serie de walk en frame estético
                 .Body.Walk(.Heading).Loops = 0


### PR DESCRIPTION
### Motivation

- Allow static NPCs (`Movement=1`) to play their `BodyIdle` animation when clicked, with a configurable repetition count instead of immediately remaining static. 
- Provide a simple client-side mechanism so clicks on NPCs can temporarily switch their `Body` to `BodyIdle` and then restore the original `Body`.

### Description

- Added two NPC configuration fields: `Movement` and `BodyIdleClickLoops` to `NpcDatas` and the runtime `Char` structure to store behavior and loop count.`
- Read `Movement` and `BodyIdleClickLoops` from NPC config in `CODIGO/Recursos.bas` and propagate them into character creation in `CODIGO/Protocol.bas` (`HandleCharacterCreate`).
- Implemented `TriggerNpcBodyIdleClick(TileX, TileY)` in `CODIGO/TileEngine_Chars.bas` which finds the clicked NPC, checks `Movement=1`, sets `Body` to `BodyIdle`, initializes the animation loops and schedules a return `Body` value.
- Hooked the click flow in `CODIGO/ModGameplayUI.bas` to call `TriggerNpcBodyIdleClick(tX, tY)` before `WriteLeftClick`, and updated rendering logic in `CODIGO/engine.bas` to respect a new `IdleClickActive` flag and restore the original `Body` when the temporary animation ends.

### Testing

- Ran `git diff --check` to validate no whitespace/patch errors and it passed. 
- Verified working-tree changes with `git status --short` to ensure expected files were updated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ad31cf32c8328b162174e06e8efb7)