### PR TITLE
Add Patreon Noble and Emperador tiers and badge colors

### DIFF
--- a/CODIGO/TileEngine.bas
+++ b/CODIGO/TileEngine.bas
@@ -166,6 +166,8 @@ Public Enum eTipoUsuario
     aventurero
     heroe
     Legend
+    Noble
+    Emperador
 End Enum
 
 Public Type tMascota

--- a/CODIGO/engine.bas
+++ b/CODIGO/engine.bas
@@ -1860,6 +1860,10 @@ Sub Char_Render(ByVal charindex As Long, ByVal PixelOffsetX As Integer, ByVal Pi
                     Call RGBAList(color, 255, 0, 0, IIf(.Invisible, 160, 255))
                 Case eTipoUsuario.Legend
                     Call RGBAList(color, 255, 255, 0, IIf(.Invisible, 120, 255))
+                Case eTipoUsuario.Noble
+                    Call RGBAList(color, 138, 43, 226, IIf(.Invisible, 120, 255)) ' Purple
+                Case eTipoUsuario.Emperador
+                    Call RGBAList(color, 255, 215, 0, IIf(.Invisible, 120, 255)) ' Gold
             End Select
             Dim txt_width As Long
             If .alias <> vbNullString Then


### PR DESCRIPTION
### Motivation
- Support two new Patreon tiers sent by the server (`Noble`, `Emperador`) and show distinct badge colors while remaining backward compatible with existing servers.

### Description
- Modified `CODIGO/TileEngine.bas` to extend `Public Enum eTipoUsuario` with `Noble` and `Emperador`, resulting in exact enum values: `User = 0`, `aventurero = 1`, `heroe = 2`, `Legend = 3`, `Noble = 4`, `Emperador = 5`.
- Modified `CODIGO/engine.bas` to add purple and gold badge rendering for the new tiers while keeping Aventurero, Héroe and Leyenda colors unchanged; the rendering snippet is now:

```vb
Select Case .tipoUsuario
    Case eTipoUsuario.aventurero
        Call RGBAList(color, 0, 255, 0, IIf(.Invisible, 120, 255))
    Case eTipoUsuario.heroe
        Call RGBAList(color, 255, 0, 0, IIf(.Invisible, 160, 255))
    Case eTipoUsuario.Legend
        Call RGBAList(color, 255, 255, 0, IIf(.Invisible, 120, 255))
    Case eTipoUsuario.Noble
        Call RGBAList(color, 138, 43, 226, IIf(.Invisible, 120, 255)) ' Purple
    Case eTipoUsuario.Emperador
        Call RGBAList(color, 255, 215, 0, IIf(.Invisible, 120, 255)) ' Gold
End Select
```
- Protocol deserialization was not changed and `.tipoUsuario` continues to be read with `Reader.ReadInt8()` so packet formats remain identical.

### Testing
- Ran `git diff --check` and it succeeded with no whitespace or diff issues.
- Searched usages with `rg -n "tipoUsuario|eTipoUsuario|aventurero|heroe|Legend" CODIGO` to confirm locations and updated the rendering logic accordingly (command completed successfully).
- Changes committed; no protocol or serialization tests were required because `Reader.ReadInt8()` usage was left unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b108fed808328a7a1150d00a4315c)