### PR TITLE
Apply 'Ocultar' macro sanction when jail checkbox is set and parse `txtSegundos` value

### DIFF
--- a/CODIGO/frmPanelGm.frm
+++ b/CODIGO/frmPanelGm.frm
@@ -3379,12 +3379,12 @@ Public Sub CadenaChat(ByVal chat As String)
                 Case InStr(Cadena, "Ocultar") > 0
                     If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(nombre & ",Macro de Ocultar ", "MacroOcultar.txt")
                     'Call ParseUserCommand("/MENSAJEINFORMACION " & nombre & "@" & "INFORMACION: Le recordamos que el uso de macros o programas externos está estrictamente prohibido y puede resultar en sanciones.")
-                    If frmPanelgm.chkOcultar.value = 1 Then
+                    If frmPanelgm.chkOcultar.value = 1 Or frmPanelgm.chkOcultarCarcel.value = 1 Then
                         If frmPanelgm.cboListaUsus.text = nombre Then
                             ' Obtener el tiempo actual en milisegundos
                             Dim TiempoActual As Single
                             TiempoActual = Timer
-                            If TiempoActual - TiempoAnterior < frmPanelgm.txtSegundos Then
+                            If TiempoActual - TiempoAnterior < val(frmPanelgm.txtSegundos.Text) Then
                                 If DebeAplicarSancionMacroPorTimestamp(Cadena) Then
                                     Call AplicarSancionMacro(nombre, frmPanelgm.chkOcultar.value = 1, frmPanelgm.chkOcultarCarcel.value = 1)
                                     Call RegistrarTimestampSancionadoMacro(Cadena)


### PR DESCRIPTION
### Motivation
- Fix a bug where the "Ocultar" macro did not trigger sanctions when only `chkOcultarCarcel` was checked and ensure the seconds threshold is read as a numeric value from the textbox.

### Description
- Change the condition to `If frmPanelgm.chkOcultar.value = 1 Or frmPanelgm.chkOcultarCarcel.value = 1 Then` so sanctions run when either checkbox is enabled.
- Use `val(frmPanelgm.txtSegundos.Text)` in the time comparison to explicitly convert the textbox content to a numeric value before comparing.

### Testing
- Ran `git diff --check` to validate changes and `git status --short` to confirm the working tree, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d652f6fc48328961bef94ca75a6d5)