### PR TITLE
Honor Ocultar jail option and change sanction handling to prefer jail over client close

### DIFF
--- a/CODIGO/frmPanelGm.frm
+++ b/CODIGO/frmPanelGm.frm
@@ -3379,7 +3379,7 @@ Public Sub CadenaChat(ByVal chat As String)
                 Case InStr(Cadena, "Ocultar") > 0
                     If chkInfoTXT.value = 1 Then Resultado = GuardarTextoEnArchivo(nombre & ",Macro de Ocultar ", "MacroOcultar.txt")
                     'Call ParseUserCommand("/MENSAJEINFORMACION " & nombre & "@" & "INFORMACION: Le recordamos que el uso de macros o programas externos está estrictamente prohibido y puede resultar en sanciones.")
-                    If frmPanelgm.chkOcultar.value = 1 Then
+                    If frmPanelgm.chkOcultar.value = 1 Or frmPanelgm.chkOcultarCarcel.value = 1 Then
                         If frmPanelgm.cboListaUsus.text = nombre Then
                             ' Obtener el tiempo actual en milisegundos
                             Dim TiempoActual As Single
@@ -3524,8 +3524,10 @@ Private Sub AplicarSancionMacro(ByVal nombre As String, ByVal cerrarCliente As B
         tiempoCarcel = 600
     End If
 
-    If mandarCarcel And Not EstaUsuarioEnMapa66(nombre) Then
-        Call ParseUserCommand("/CARCEL " & nombre & "@Uso de programas externos, Macros o Cheat@" & tiempoCarcel)
+    If mandarCarcel Then
+        If Not EstaUsuarioEnMapa66(nombre) Then
+            Call ParseUserCommand("/CARCEL " & nombre & "@Uso de programas externos, Macros o Cheat@" & tiempoCarcel)
+        End If
     ElseIf cerrarCliente Then
         Call WriteCerraCliente(nombre)
     End If


### PR DESCRIPTION
### Motivation
- Ensure the "Ocultar" macro handling respects both the close-client and jail options so moderators can choose to send offenders to jail for that macro.
- Prevent unintended client closures when the jail option is selected but the target is on map 66 by adjusting the sanction decision flow in `AplicarSancionMacro`.

### Description
- Updated the `Ocultar` case in `CadenaChat` to check `frmPanelgm.chkOcultarCarcel` in addition to `frmPanelgm.chkOcultar` when deciding to apply sanctions. 
- Reworked `AplicarSancionMacro` control flow to first handle the `mandarCarcel` branch and only call `ParseUserCommand("/CARCEL ...")` when `EstaUsuarioEnMapa66(nombre)` is false. 
- Changed fallback behavior so that when `mandarCarcel` is true but the user is on map 66, the function no longer falls through to the `cerrarCliente` branch, preventing an unintended client close.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d6a683d088328b523795fc86725f6)