### PR TITLE
Use OGG/BASS for map music and start map song on initial login

### DIFF
--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -2168,6 +2168,7 @@ Private Sub HandleUserCharIndexInServer()
         Call frmMain.SetCoordColor(RGB(170, 0, 0))
     End If
     Call UpdateMapPos
+    Call PlayCurrentMapMusic
     g_game_state.state = e_state_gameplay_screen
     Exit Sub
 HandleUserCharIndexInServer_Err:
@@ -2347,6 +2348,9 @@ Private Sub HandleCharacterCreate()
         End If
     End With
     Call RefreshAllChars
+    If charindex = UserCharIndex Then
+        Call PlayCurrentMapMusic
+    End If
     Exit Sub
 errhandler:
     Call RegistrarError(Err.Number, Err.Description, "Protocol.HandleCharacterCreate", Erl)

--- a/CODIGO/TileEngine_Map.bas
+++ b/CODIGO/TileEngine_Map.bas
@@ -48,19 +48,7 @@ Sub SwitchMap(ByVal map As Integer, Optional ByVal NewResourceMap As Integer = 0
     CurMap = map
     
     
-    If ao20audio.MusicEnabled Then
-            If UserCharIndex > 0 Then
-                With charlist(UserCharIndex)
-                    Dim new_music As Integer
-                    new_music = MapData(.Pos.x, .Pos.y).zone.Musica
-                    If new_music > 0 Then
-                        Call ao20audio.PlayMidi(new_music, True)
-                    Else
-                        Call ao20audio.PlayMidi(MapDat.music_numberLow, True)
-                    End If
-                End With
-            End If
-    End If
+    Call PlayCurrentMapMusic
     
     Dim HaveAudio As Boolean
     If bRain Then
@@ -100,6 +88,45 @@ Sub SwitchMap(ByVal map As Integer, Optional ByVal NewResourceMap As Integer = 0
     Exit Sub
 SwitchMap_Err:
     Call RegistrarError(Err.Number, Err.Description, "TileEngine_Map.SwitchMap", Erl)
+    Resume Next
+End Sub
+
+Public Sub PlayCurrentMapMusic()
+    On Error GoTo PlayCurrentMapMusic_Err
+
+    If ao20audio.MusicEnabled Then
+        Dim resolvedMusicId As Integer
+        Dim usedFallback As Boolean
+
+        resolvedMusicId = 0
+        usedFallback = True
+
+        If UserCharIndex > 0 Then
+            With charlist(UserCharIndex)
+                resolvedMusicId = MapData(.Pos.x, .Pos.y).zone.Musica
+                If resolvedMusicId > 0 Then
+                    usedFallback = False
+                End If
+            End With
+        End If
+
+        If usedFallback Then
+            resolvedMusicId = MapDat.music_numberLow
+        End If
+
+        #If DEBUG_AUDIO = 1 Then
+            frmDebug.add_text_tracebox "Map music resolve: map=" & CStr(CurMap) & _
+                                       " musicId=" & CStr(resolvedMusicId) & _
+                                       " ogg=ost_" & CStr(resolvedMusicId) & ".ogg" & _
+                                       " fallbackMapDat=" & CStr(usedFallback)
+        #End If
+
+        Call ao20audio.PlayMapMusic(resolvedMusicId)
+    End If
+
+    Exit Sub
+PlayCurrentMapMusic_Err:
+    Call RegistrarError(Err.Number, Err.Description, "TileEngine_Map.PlayCurrentMapMusic", Erl)
     Resume Next
 End Sub
 

--- a/CODIGO/ao20audio.bas
+++ b/CODIGO/ao20audio.bas
@@ -64,6 +64,18 @@ Public Sub PlayRandomOggSong(ByVal maxTrack As Integer, Optional ByVal looping A
     Call ao20audio.PlayMusic(filename, looping)
 End Sub
 
+Public Sub PlayMapMusic(ByVal musicId As Integer)
+    Dim filename As String
+
+    If musicId <= 0 Then
+        Call ao20audio.StopMusic
+        Exit Sub
+    End If
+
+    filename = "ost_" & CStr(musicId) & ".ogg"
+    Call ao20audio.PlayMusic(filename, True)
+End Sub
+
 Public Sub CreateAudioEngine(ByVal hWnd As Long, ByRef dx8 As DirectX8, ByRef renderer As clsAudioEngine)
     On Error GoTo AudioEngineInitErr:
     If AudioEnabled Then


### PR DESCRIPTION
### Motivation
- Ensure map/zone songs use the new OGG/BASS backend so songs loop correctly and are not started via legacy MIDI calls on map transition.  
- Fix a case where no music started after initial login by running the shared map-music logic once the player character is present.  
- Keep MIDI support for legacy/explicit callers while consolidating map music to the OGG path.

### Description
- Added `PlayMapMusic` in `CODIGO/ao20audio.bas` which converts a music id to the `ost_<id>.ogg` filename, stops safely for non-positive ids, and calls `PlayMusic(filename, True)`.  
- Replaced the old MIDI-based map-music block in `SwitchMap` with a call to the shared `PlayCurrentMapMusic` helper in `CODIGO/TileEngine_Map.bas`.  
- Implemented `PlayCurrentMapMusic` in `CODIGO/TileEngine_Map.bas` which resolves music by preferring `MapData(.Pos.x, .Pos.y).zone.Musica` when `UserCharIndex > 0`, falling back to `MapDat.music_numberLow`, then calls `ao20audio.PlayMapMusic(resolvedMusicId)`.  
- Added `#If DEBUG_AUDIO = 1 Then` traces showing `CurMap`, resolved music id, computed OGG filename, and whether the fallback was used.  
- Triggered `PlayCurrentMapMusic` after `UserCharIndex` is set in `Protocol.HandleUserCharIndexInServer` and after a local character is created in `Protocol.HandleCharacterCreate` to ensure music starts on initial login without duplicating logic or removing MIDI backend.

### Testing
- Ran `git diff --check` with no whitespace errors reported.  
- Searched for updated call sites with `rg -n "PlayMidi\(|PlayMapMusic|PlayCurrentMapMusic|Map music resolve"` to verify the new helper is present and `PlayMidi` call sites remain unchanged.  
- Verified that `PlayCurrentMapMusic` is invoked on map switch and on initial user index/character creation by inspecting the modified `Protocol.bas` and `TileEngine_Map.bas` locations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4413965348832881021e7f5a4c3315)