### PR TITLE
Add /CASTLE whitelist packet command

### DIFF
--- a/CODIGO/PacketId.bas
+++ b/CODIGO/PacketId.bas
@@ -528,6 +528,7 @@ Public Enum ClientPacketID
     eStartAutomatedAction
     ePetFollowAll
     eAntiMacroMessage
+    eModifyCastleWhiteList
     eMaxPacket
     [PacketCount]
 End Enum

--- a/CODIGO/ProtocolCmdParse.bas
+++ b/CODIGO/ProtocolCmdParse.bas
@@ -624,6 +624,16 @@ Public Sub ParseUserCommand(ByVal RawCommand As String)
                 End If
             Case "/RMATA"
                 Call WriteKillNPC
+            Case "/CASTLE"
+                If notNullArguments Then
+                    tmpArr = Split(ArgumentosRaw, " ")
+                    If UBound(tmpArr) = 1 Then
+                        Call WriteModifyCastleWhiteList(tmpArr(0) & " " & tmpArr(1))
+                    Else
+                        Call ShowConsoleMsg(JsonLanguage.Item("MENSAJE_FALTAN_PARAMETROS_UTILICE"))
+                    End If
+                End If
+                
             Case "/ADVERTENCIA", "/WARNING"
                 If notNullArguments Then
                     tmpArr = Split(ArgumentosRaw, "@", 2)

--- a/CODIGO/Protocol_Writes.bas
+++ b/CODIGO/Protocol_Writes.bas
@@ -3302,6 +3302,17 @@ WriteCrearEvento_Err:
     '</EhFooter>
 End Sub
 
+Public Sub WriteModifyCastleWhiteList(ByVal command As String)
+    On Error GoTo WriteModifyCastleWhiteList_Err
+    Call Writer.WriteInt16(ClientPacketID.eModifyCastleWhiteList)
+    Call Writer.WriteString8(command)
+    Call modNetwork.send(Writer)
+    Exit Sub
+WriteModifyCastleWhiteList_Err:
+    Call Writer.Clear
+    Call RegistrarError(Err.Number, Err.Description, "Argentum20.Protocol_Writes.WriteModifyCastleWhiteList", Erl)
+End Sub
+
 ''
 ' Writes the "KillNPC" message to the outgoing data buffer.
 '


### PR DESCRIPTION
Introduces a new client packet ID (`eModifyCastleWhiteList`) and adds support for the `/CASTLE` user command in command parsing. When two space-separated arguments are provided, the client now sends them through a new `WriteModifyCastleWhiteList` protocol writer; otherwise it shows the missing-parameters message.