### PR TITLE
Harden /CASTLE client-side validation and eligibility check

### DIFF
--- a/CODIGO/ProtocolCmdParse.bas
+++ b/CODIGO/ProtocolCmdParse.bas
@@ -626,12 +626,33 @@ Public Sub ParseUserCommand(ByVal RawCommand As String)
                 Call WriteKillNPC
             Case "/CASTLE"
                 If notNullArguments Then
-                    tmpArr = Split(ArgumentosRaw, " ")
+                    Dim CastleArguments As String
+                    Dim Action          As String
+                    Dim CharacterName   As String
+
+                    CastleArguments = Trim$(ArgumentosRaw)
+                    CastleArguments = NormalizeCommandSpaces(CastleArguments)
+                    tmpArr = Split(CastleArguments, " ", 3)
+
                     If UBound(tmpArr) = 1 Then
-                        Call WriteModifyCastleWhiteList(tmpArr(0) & " " & tmpArr(1))
+                        Action = UCase$(Trim$(tmpArr(0)))
+                        CharacterName = Trim$(tmpArr(1))
+
+                        If (Action = "ADD" Or Action = "REMOVE") And LenB(CharacterName) <> 0 Then
+                            ' Client-side UX check only. Server must enforce castle ownership / Patreon authorization.
+                            If IsCastleWhiteListEligible() Then
+                                Call WriteModifyCastleWhiteList(Action & " " & CharacterName)
+                            Else
+                                Call ShowConsoleMsg("Este comando está disponible solo para Patreons con castillo.")
+                            End If
+                        Else
+                            Call ShowConsoleMsg("Uso: /CASTLE ADD <personaje> o /CASTLE REMOVE <personaje>")
+                        End If
                     Else
-                        Call ShowConsoleMsg(JsonLanguage.Item("MENSAJE_FALTAN_PARAMETROS_UTILICE"))
+                        Call ShowConsoleMsg("Uso: /CASTLE ADD <personaje> o /CASTLE REMOVE <personaje>")
                     End If
+                Else
+                    Call ShowConsoleMsg("Uso: /CASTLE ADD <personaje> o /CASTLE REMOVE <personaje>")
                 End If
                 
             Case "/ADVERTENCIA", "/WARNING"
@@ -1970,4 +1991,33 @@ Private Function AEMAILSplit(ByRef text As String) As String()
 AEMAILSplit_Err:
     Call RegistrarError(Err.Number, Err.Description, "ProtocolCmdParse.AEMAILSplit", Erl)
     Resume Next
+End Function
+
+Private Function NormalizeCommandSpaces(ByVal text As String) As String
+    On Error GoTo NormalizeCommandSpaces_Err
+
+    text = Trim$(text)
+    Do While InStr(1, text, "  ") > 0
+        text = Replace$(text, "  ", " ")
+    Loop
+
+    NormalizeCommandSpaces = text
+    Exit Function
+NormalizeCommandSpaces_Err:
+    Call RegistrarError(Err.Number, Err.Description, "ProtocolCmdParse.NormalizeCommandSpaces", Erl)
+End Function
+
+Private Function IsCastleWhiteListEligible() As Boolean
+    On Error GoTo IsCastleWhiteListEligible_Err
+
+    If UserCharIndex < LBound(charlist) Or UserCharIndex > UBound(charlist) Then Exit Function
+
+    Select Case charlist(UserCharIndex).tipoUsuario
+        Case eTipoUsuario.Noble, eTipoUsuario.Emperador
+            IsCastleWhiteListEligible = True
+    End Select
+
+    Exit Function
+IsCastleWhiteListEligible_Err:
+    Call RegistrarError(Err.Number, Err.Description, "ProtocolCmdParse.IsCastleWhiteListEligible", Erl)
 End Function

--- a/CODIGO/Protocol_Writes.bas
+++ b/CODIGO/Protocol_Writes.bas
@@ -3304,6 +3304,12 @@ End Sub
 
 Public Sub WriteModifyCastleWhiteList(ByVal command As String)
     On Error GoTo WriteModifyCastleWhiteList_Err
+
+    command = Trim$(command)
+    If LenB(command) = 0 Then Exit Sub
+    If Len(command) > 255 Then Exit Sub
+    If HasControlCharacters(command) Then Exit Sub
+
     Call Writer.WriteInt16(ClientPacketID.eModifyCastleWhiteList)
     Call Writer.WriteString8(command)
     Call modNetwork.send(Writer)
@@ -3312,6 +3318,26 @@ WriteModifyCastleWhiteList_Err:
     Call Writer.Clear
     Call RegistrarError(Err.Number, Err.Description, "Argentum20.Protocol_Writes.WriteModifyCastleWhiteList", Erl)
 End Sub
+
+Private Function HasControlCharacters(ByVal value As String) As Boolean
+    On Error GoTo HasControlCharacters_Err
+
+    Dim i         As Long
+    Dim charCode  As Integer
+
+    For i = 1 To Len(value)
+        charCode = AscW(Mid$(value, i, 1))
+        If (charCode >= 0 And charCode < 32) Or charCode = 127 Then
+            HasControlCharacters = True
+            Exit Function
+        End If
+    Next i
+
+    Exit Function
+HasControlCharacters_Err:
+    Call RegistrarError(Err.Number, Err.Description, "Argentum20.Protocol_Writes.HasControlCharacters", Erl)
+    HasControlCharacters = True
+End Function
 
 ''
 ' Writes the "KillNPC" message to the outgoing data buffer.


### PR DESCRIPTION
### Motivation
- Prevent malformed `/CASTLE` commands from being sent by the client while keeping the existing packet protocol intact and adding a lightweight UX-only eligibility check.

### Description
- Validate and normalize `/CASTLE` arguments in `ProtocolCmdParse.bas` so only `ADD <characterName>` or `REMOVE <characterName>` (with `Action` normalized via `UCase$`) are accepted and malformed inputs show usage text and do not send a packet.
- Add `NormalizeCommandSpaces` helper and `IsCastleWhiteListEligible` that uses the existing local `charlist(UserCharIndex).tipoUsuario` to allow only `eTipoUsuario.Noble` and `eTipoUsuario.Emperador` for sending the command, with the comment: `Client-side UX check only. Server must enforce castle ownership / Patreon authorization.`
- Keep the wire protocol unchanged by preserving the exact send sequence `Call Writer.WriteInt16(ClientPacketID.eModifyCastleWhiteList)` followed by `Call Writer.WriteString8(command)`, and add defensive validation in `WriteModifyCastleWhiteList` to `Trim$` the command and reject empty strings, strings longer than 255 characters, or those containing control characters.

### Testing
- Ran `git diff --check` to validate no whitespace/patch issues and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4eb6941e9c83288bf05c288cb5b704)