### PR TITLE
Refactorizar lógica de beneficios de clan y corregir errores de renderizado.

### DIFF
--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -4302,26 +4302,15 @@ Private Sub HandleGuildNews()
             .porciento = JsonLanguage.Item("MENSAJE_CLAN_NIVEL_MAXIMO")
             .expcount = JsonLanguage.Item("MENSAJE_CLAN_NIVEL_MAXIMO")
         End If
-        '.expne = "Experiencia necesaria: " & expne
-        Select Case ClanNivel
-            Case 1
-                .beneficios = JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(1)
-            Case 2
-                .beneficios = JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(2)
-            Case 3
-                .beneficios = JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & vbCrLf & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(3)
-            Case 4
-                .beneficios = JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & vbCrLf & JsonLanguage.Item("MENSAJE_SEGURO_CLAN") & vbCrLf & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(4)
-            Case 5
-                .beneficios = JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & vbCrLf & JsonLanguage.Item("MENSAJE_SEGURO_CLAN") & vbCrLf & JsonLanguage.Item("MENSAJE_VER_VIDA_MANA") _
-                        & vbCrLf & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(5)
-            Case 6
-                .beneficios = JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & vbCrLf & JsonLanguage.Item("MENSAJE_SEGURO_CLAN") & vbCrLf & JsonLanguage.Item("MENSAJE_VER_VIDA_MANA") _
-                        & vbCrLf & JsonLanguage.Item("MENSAJE_VERSE_INVISIBLE") & vbCrLf & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(6)
-            Case 7
-                .beneficios = JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & vbCrLf & JsonLanguage.Item("MENSAJE_SEGURO_CLAN") & vbCrLf & JsonLanguage.Item("MENSAJE_VER_VIDA_MANA") _
-                        & vbCrLf & JsonLanguage.Item("MENSAJE_VERSE_INVISIBLE") & vbCrLf & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(7)
-        End Select
+        
+        Dim beneficiosTxt As String
+        beneficiosTxt = vbNullString
+        If ClanNivel >= cfgGuildLevelCallSupport Then beneficiosTxt = beneficiosTxt & JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & vbCrLf
+        If ClanNivel >= cfgGuildLevelSafe Then beneficiosTxt = beneficiosTxt & JsonLanguage.Item("MENSAJE_SEGURO_CLAN") & vbCrLf
+        If ClanNivel >= cfgGuildLevelShowHPBar Then beneficiosTxt = beneficiosTxt & JsonLanguage.Item("MENSAJE_VER_VIDA_MANA") & vbCrLf
+        If ClanNivel >= cfgGuildLevelSeeInvisible Then beneficiosTxt = beneficiosTxt & JsonLanguage.Item("MENSAJE_VERSE_INVISIBLE") & vbCrLf
+        beneficiosTxt = beneficiosTxt & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(ClanNivel)
+        .beneficios = beneficiosTxt
     End With
     frmGuildNews.Show vbModeless, GetGameplayForm()
     Exit Sub
@@ -4480,31 +4469,14 @@ Private Sub HandleGuildLeaderInfo()
         End If
         Dim Padding As String
         Padding = Space$(18)
-        Select Case Nivel
-            Case 1
-                .beneficios = Padding & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(1)
-                .maxMiembros = cfgGuildMembersByLevel(1)
-            Case 2
-                .beneficios = Padding & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(2)
-                .maxMiembros = cfgGuildMembersByLevel(2)
-            Case 3
-                .beneficios = Padding & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(3) & " / " & JsonLanguage.Item("MENSAJE_PEDIR_AYUDA")
-                .maxMiembros = cfgGuildMembersByLevel(3)
-            Case 4
-                .beneficios = Padding & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(4) & " / " & JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & " / " & JsonLanguage.Item("MENSAJE_SEGURO_CLAN")
-                .maxMiembros = cfgGuildMembersByLevel(4)
-            Case 5
-                .beneficios = Padding & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(5) & " / " & JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & " / " & JsonLanguage.Item("MENSAJE_SEGURO_CLAN") & " / " & JsonLanguage.Item("MENSAJE_VER_VIDA_MANA")
-                .maxMiembros = cfgGuildMembersByLevel(5)
-            Case 6
-                .beneficios = Padding & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(6) & " / " & JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & " / " & JsonLanguage.Item("MENSAJE_SEGURO_CLAN") & " / " & JsonLanguage.Item("MENSAJE_VER_VIDA_MANA") _
-                        & " / " & JsonLanguage.Item("MENSAJE_VERSE_INVISIBLE")
-                .maxMiembros = cfgGuildMembersByLevel(6)
-            Case 7
-            .beneficios = Padding & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(7) & " / " & JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & " / " & JsonLanguage.Item("MENSAJE_SEGURO_CLAN") & " / " & JsonLanguage.Item("MENSAJE_VER_VIDA_MANA") _
-                        & " / " & JsonLanguage.Item("MENSAJE_VERSE_INVISIBLE")
-            .maxMiembros = cfgGuildMembersByLevel(7)
-        End Select
+        Dim beneficiosTxt As String
+        beneficiosTxt = Padding & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(Nivel)
+        If Nivel >= cfgGuildLevelCallSupport Then beneficiosTxt = beneficiosTxt & " / " & JsonLanguage.Item("MENSAJE_PEDIR_AYUDA")
+        If Nivel >= cfgGuildLevelSafe Then beneficiosTxt = beneficiosTxt & " / " & JsonLanguage.Item("MENSAJE_SEGURO_CLAN")
+        If Nivel >= cfgGuildLevelShowHPBar Then beneficiosTxt = beneficiosTxt & " / " & JsonLanguage.Item("MENSAJE_VER_VIDA_MANA")
+        If Nivel >= cfgGuildLevelSeeInvisible Then beneficiosTxt = beneficiosTxt & " / " & JsonLanguage.Item("MENSAJE_VERSE_INVISIBLE")
+        .beneficios = beneficiosTxt
+        .maxMiembros = cfgGuildMembersByLevel(Nivel)
         .Show , GetGameplayForm()
     End With
     Exit Sub

--- a/CODIGO/engine.bas
+++ b/CODIGO/engine.bas
@@ -1647,7 +1647,7 @@ Sub Char_Render(ByVal charindex As Long, ByVal PixelOffsetX As Integer, ByVal Pi
                 End If
             End If
             If UserCharIndex > 0 Then
-                If (verVidaClan And Not .Invisible) Or dibujaMiembroClan Or charlist(UserCharIndex).priv = 5 Then
+                If (verVidaClan And Not .Invisible) Or charlist(UserCharIndex).priv = 5 Then
                     OffsetYname = 8
                     OffsetYClan = 8
                     Call DibujarVidaChar(charindex, PixelOffsetX, PixelOffsetY, OffsetYname, OffsetYClan)
@@ -2013,7 +2013,7 @@ Public Sub DibujarVidaChar(ByVal charindex As Integer, ByVal PixelOffsetX As Int
             OffsetYname = 12
             OffsetYClan = 12
             Engine_Draw_Box PixelOffsetX + .Body.BodyOffset.x, PixelOffsetY + 38 + .Body.BodyOffset.y, 33, 4, RGBA_From_Comp(10, 10, 10)
-            Engine_Draw_Box PixelOffsetX + 1 + .Body.BodyOffset.y, PixelOffsetY + 38 + .Body.BodyOffset.y, .UserMinMAN / .UserMaxMAN * 31, 3, RGBA_From_Comp(0, 100, 255)
+            Engine_Draw_Box PixelOffsetX + 1 + .Body.BodyOffset.X, PixelOffsetY + 38 + .Body.BodyOffset.Y, .UserMinMAN / .UserMaxMAN * 31, 3, RGBA_From_Comp(0, 100, 255)
         End If
     End With
 End Sub


### PR DESCRIPTION
Reemplaza los Select Case repetitivos de HandleGuildNews y HandleGuildLeaderInfo por lógica condicional dinámica basada en los umbrales de nivel de clan configurados en el servidor (cfgGuildLevelCallSupport, cfgGuildLevelSafe,  cfgGuildLevelShowHPBar, cfgGuildLevelSeeInvisible). Antes, cada nivel de desbloqueo estaba hardcodeado directo en el número del Case, lo que generaba un desfasaje real contra los valores configurados en Clanes.dat (por ejemplo, "Pedir ayuda" se mostraba disponible en nivel 3 en el cliente, cuando el servidor lo requiere en nivel 4). Esto reduce duplicación de código y hace que el sistema de beneficios refleje siempre la configuración real del servidor.

También corrige dos errores de renderizado en Char_Render y DibujarVidaChar:
- Saca la condición "Or dibujaMiembroClan" que otorgaba de forma indebida la recompensa de ver vida/maná (ShowHPBar) a cualquier clan que solo hubiera alcanzado el nivel de SeeInvisible, sin chequear su propio umbral configurado.
- Corrige un typo en el offset X de la barra de maná en DibujarVidaChar, que usaba BodyOffset.y en vez de BodyOffset.x, desalineando la barra en cuerpos donde ambos offsets difieren.

Relacionado con el PR de servidor #1687, que agrega el cooldown a la llamada de apoyo del clan y amplía el tipo de dato de experiencia de clan a Long. Este PR depende de esos cambios de servidor para que los 4 umbrales de recompensa (cfgGuildLevel*) que ahora se comparan acá lleguen correctamente configurados desde Clanes.dat.