### PR TITLE
Frenar el buffer anterior antes de reemplazarlo en PlayAmbient

### DIFF
--- a/CODIGO/clsAudioEngine.cls
+++ b/CODIGO/clsAudioEngine.cls
@@ -1042,6 +1042,10 @@ Public Function PlayAmbient(ByVal id As Integer, Optional ByVal looping As Boole
         frmDebug.add_text_tracebox "PlayAmbient, track " & tid & " id: " & id
     #End If
     With mAudioTracks(tid)
+        If Not .buffer Is Nothing Then
+            .buffer.Stop
+            .buffer.SetCurrentPosition 0
+        End If
         .Name = id
         Set .Buffer = mDirectSound.DuplicateSoundBuffer(ByVal mBuffer(id))
         Call StartPlaying(.Buffer, IIf(looping, DSBPLAY_LOOPING, DSBPLAY_DEFAULT), volume, pan)


### PR DESCRIPTION
Antes de asignar un buffer de audio nuevo a un track en PlayAmbient, se frena el buffer que esté sonando en ese momento y se resetea su posición. Esto evita que el audio del track anterior siga sonando cuando se asigna un sonido nuevo al mismo track.

Como PlayAmbient siempre usa el mismo slot (el reservado para audio ambiente), esto afecta a todo lo que pase por ahí: sonido de lluvia, de nieve y ambiente de mapa. Sin este fix, si sonaba un loop (por ejemplo, lluvia) y se reemplazaba por otro sonido en el mismo canal (por ejemplo, al terminar de llover), el buffer viejo quedaba huérfano reproduciéndose indefinidamente en paralelo, aunque visualmente la lluvia ya hubiera terminado.