### PR TITLE
Refactorizar configuración de niveles de clan y manejo de experiencia

### DIFF
--- a/CODIGO/Declares.bas
+++ b/CODIGO/Declares.bas
@@ -45,7 +45,7 @@ Public cfgGuildLevelSeeInvisible As Byte
 Public cfgGuildLevelSafe As Byte
 Public cfgGuildLevelShowHPBar As Byte
 Public cfgMaxGuildLevel As Byte
-Public cfgGuildMembersByLevel(1 To 7) As Byte
+Public cfgGuildMembersByLevel() As Byte
 
 Public Enum tMacroButton
     Inventario = 1

--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -4264,8 +4264,8 @@ Private Sub HandleGuildNews()
     Dim List()      As String
     Dim i           As Long
     Dim ClanNivel   As Byte
-    Dim expacu      As Integer
-    Dim ExpNe       As Integer
+    Dim expacu      As Long
+    Dim ExpNe       As Long
     Dim guildList() As String
     frmGuildNews.news = Reader.ReadString8()
     'Get list of existing guilds
@@ -4289,8 +4289,8 @@ Private Sub HandleGuildNews()
         'frmdebug.add_text_tracebox guildList(i)
     Next i
     ClanNivel = Reader.ReadInt8()
-    expacu = Reader.ReadInt16()
-    ExpNe = Reader.ReadInt16()
+    expacu = reader.ReadInt32()
+    ExpNe = reader.ReadInt32()
     With frmGuildNews
         .lblMiembros.Caption = cantidad
         .expcount.Caption = expacu & "/" & ExpNe
@@ -4302,26 +4302,14 @@ Private Sub HandleGuildNews()
             .porciento = JsonLanguage.Item("MENSAJE_CLAN_NIVEL_MAXIMO")
             .expcount = JsonLanguage.Item("MENSAJE_CLAN_NIVEL_MAXIMO")
         End If
-        '.expne = "Experiencia necesaria: " & expne
-        Select Case ClanNivel
-            Case 1
-                .beneficios = JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(1)
-            Case 2
-                .beneficios = JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(2)
-            Case 3
-                .beneficios = JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & vbCrLf & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(3)
-            Case 4
-                .beneficios = JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & vbCrLf & JsonLanguage.Item("MENSAJE_SEGURO_CLAN") & vbCrLf & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(4)
-            Case 5
-                .beneficios = JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & vbCrLf & JsonLanguage.Item("MENSAJE_SEGURO_CLAN") & vbCrLf & JsonLanguage.Item("MENSAJE_VER_VIDA_MANA") _
-                        & vbCrLf & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(5)
-            Case 6
-                .beneficios = JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & vbCrLf & JsonLanguage.Item("MENSAJE_SEGURO_CLAN") & vbCrLf & JsonLanguage.Item("MENSAJE_VER_VIDA_MANA") _
-                        & vbCrLf & JsonLanguage.Item("MENSAJE_VERSE_INVISIBLE") & vbCrLf & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(6)
-            Case 7
-                .beneficios = JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & vbCrLf & JsonLanguage.Item("MENSAJE_SEGURO_CLAN") & vbCrLf & JsonLanguage.Item("MENSAJE_VER_VIDA_MANA") _
-                        & vbCrLf & JsonLanguage.Item("MENSAJE_VERSE_INVISIBLE") & vbCrLf & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(7)
-        End Select
+        Dim beneficiosTxt As String
+        beneficiosTxt = vbNullString
+        If ClanNivel >= cfgGuildLevelCallSupport Then beneficiosTxt = beneficiosTxt & JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & vbCrLf
+        If ClanNivel >= cfgGuildLevelSafe Then beneficiosTxt = beneficiosTxt & JsonLanguage.Item("MENSAJE_SEGURO_CLAN") & vbCrLf
+        If ClanNivel >= cfgGuildLevelShowHPBar Then beneficiosTxt = beneficiosTxt & JsonLanguage.Item("MENSAJE_VER_VIDA_MANA") & vbCrLf
+        If ClanNivel >= cfgGuildLevelSeeInvisible Then beneficiosTxt = beneficiosTxt & JsonLanguage.Item("MENSAJE_VERSE_INVISIBLE") & vbCrLf
+        beneficiosTxt = beneficiosTxt & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(ClanNivel)
+        .beneficios = beneficiosTxt
     End With
     frmGuildNews.Show vbModeless, GetGameplayForm()
     Exit Sub
@@ -4461,13 +4449,13 @@ Private Sub HandleGuildLeaderInfo()
                 Call .solicitudes.AddItem(List(i))
             Next i
         End If
-        Dim expacu As Integer
-        Dim ExpNe  As Integer
+        Dim expacu As Long
+        Dim ExpNe  As Long
         Dim Nivel  As Byte
         Nivel = Reader.ReadInt8()
         .Nivel = Nivel
-        expacu = Reader.ReadInt16()
-        ExpNe = Reader.ReadInt16()
+        expacu = reader.ReadInt32()
+        ExpNe = reader.ReadInt32()
         'barra
         .expcount.Caption = expacu & "/" & ExpNe
         If ExpNe > 0 Then
@@ -4480,31 +4468,14 @@ Private Sub HandleGuildLeaderInfo()
         End If
         Dim Padding As String
         Padding = Space$(18)
-        Select Case Nivel
-            Case 1
-                .beneficios = Padding & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(1)
-                .maxMiembros = cfgGuildMembersByLevel(1)
-            Case 2
-                .beneficios = Padding & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(2)
-                .maxMiembros = cfgGuildMembersByLevel(2)
-            Case 3
-                .beneficios = Padding & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(3) & " / " & JsonLanguage.Item("MENSAJE_PEDIR_AYUDA")
-                .maxMiembros = cfgGuildMembersByLevel(3)
-            Case 4
-                .beneficios = Padding & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(4) & " / " & JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & " / " & JsonLanguage.Item("MENSAJE_SEGURO_CLAN")
-                .maxMiembros = cfgGuildMembersByLevel(4)
-            Case 5
-                .beneficios = Padding & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(5) & " / " & JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & " / " & JsonLanguage.Item("MENSAJE_SEGURO_CLAN") & " / " & JsonLanguage.Item("MENSAJE_VER_VIDA_MANA")
-                .maxMiembros = cfgGuildMembersByLevel(5)
-            Case 6
-                .beneficios = Padding & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(6) & " / " & JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & " / " & JsonLanguage.Item("MENSAJE_SEGURO_CLAN") & " / " & JsonLanguage.Item("MENSAJE_VER_VIDA_MANA") _
-                        & " / " & JsonLanguage.Item("MENSAJE_VERSE_INVISIBLE")
-                .maxMiembros = cfgGuildMembersByLevel(6)
-            Case 7
-            .beneficios = Padding & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(7) & " / " & JsonLanguage.Item("MENSAJE_PEDIR_AYUDA") & " / " & JsonLanguage.Item("MENSAJE_SEGURO_CLAN") & " / " & JsonLanguage.Item("MENSAJE_VER_VIDA_MANA") _
-                        & " / " & JsonLanguage.Item("MENSAJE_VERSE_INVISIBLE")
-            .maxMiembros = cfgGuildMembersByLevel(7)
-        End Select
+        Dim beneficiosTxt As String
+        beneficiosTxt = Padding & JsonLanguage.Item("MENSAJE_BENEFICIOS_MAX_MIEMBROS") & cfgGuildMembersByLevel(Nivel)
+        If Nivel >= cfgGuildLevelCallSupport Then beneficiosTxt = beneficiosTxt & " / " & JsonLanguage.Item("MENSAJE_PEDIR_AYUDA")
+        If Nivel >= cfgGuildLevelSafe Then beneficiosTxt = beneficiosTxt & " / " & JsonLanguage.Item("MENSAJE_SEGURO_CLAN")
+        If Nivel >= cfgGuildLevelShowHPBar Then beneficiosTxt = beneficiosTxt & " / " & JsonLanguage.Item("MENSAJE_VER_VIDA_MANA")
+        If Nivel >= cfgGuildLevelSeeInvisible Then beneficiosTxt = beneficiosTxt & " / " & JsonLanguage.Item("MENSAJE_VERSE_INVISIBLE")
+        .beneficios = beneficiosTxt
+        .maxMiembros = cfgGuildMembersByLevel(Nivel)
         .Show , GetGameplayForm()
     End With
     Exit Sub
@@ -6225,6 +6196,7 @@ Public Sub HandleGuildConfig()
     cfgGuildLevelSafe = Reader.ReadInt8
     cfgGuildLevelShowHPBar = Reader.ReadInt8
     cfgMaxGuildLevel = Reader.ReadInt8()
+    ReDim cfgGuildMembersByLevel(1 To cfgMaxGuildLevel)
     Dim i As Byte
     For i = 1 To cfgMaxGuildLevel
         cfgGuildMembersByLevel(i) = Reader.ReadInt8()


### PR DESCRIPTION
Hace que la cantidad máxima de niveles de clan sea dinámica en vez de estar hardcodeada a 7, permitiendo agregar niveles nuevos únicamente desde la configuración del servidor (Clanes.dat), sin recompilar el cliente.

- Reemplaza los Select Case repetitivos de HandleGuildNews y HandleGuildLeaderInfo por lógica condicional basada en los umbrales de nivel configurados (cfgGuildLevelCallSupport, cfgGuildLevelSafe, cfgGuildLevelShowHPBar, cfgGuildLevelSeeInvisible). Antes, cada Select Case tenía los niveles 1 a 7 escritos a mano; con un clan de nivel 8 (u otro fuera de ese rango), el bloque no coincidía con ningún Case y los beneficios mostrados quedaban desactualizados.

- Cambia las variables de experiencia (expacu/ExpNe) de Integer a Long y pasa de ReadInt16() a ReadInt32() en HandleGuildNews y HandleGuildLeaderInfo, para acompañar valores de experiencia requerida por encima de 32767 (ej. GuildExpLevel7=48000). Esto evita el overflow que impedía abrir el panel de clan para fundadores en niveles altos.

- Inicializa el array cfgGuildMembersByLevel dinámicamente (ReDim) según cfgMaxGuildLevel recibido del servidor, en vez de un tamaño fijo (1 To 7), para soportar cualquier cantidad de niveles configurada.

Relacionado con el PR de servidor que agrega la sección [GUILDLEVELS] a Clanes.dat, vuelve MAX_LEVEL_GUILD dinámico (antes Const) con sus arrays asociados, corrige el mismo overflow de Integer/Long en WriteGuildNews/WriteGuildLeaderInfo/SendGuildNews, y con el PR de recursos que agrega el nivel 8 de clan a Clanes.dat (secciones GUILDEXP, MEMBERSBYLEVEL, GUILDREWARDS y GUILDPRICEACCEPTMEMBER). Los tres PRs deben mergearse juntos: el cliente asume que recibe cfgMaxGuildLevel y los umbrales ya correctos desde el servidor, y el servidor asume que existen las claves de nivel 8 en el .dat.