### PR TITLE
Corrige desfasaje de índice en el daño mostrado de armas (herrería)

### DIFF
--- a/CODIGO/frmHerrero.frm
+++ b/CODIGO/frmHerrero.frm
@@ -583,7 +583,7 @@ Private Sub lstArmas_Click()
                     List2.AddItem tmpTexts(i)
                 End If
             Next i
-            desc.Caption = "Golpe: " & ObjData(ArmasHerrero(lstArmas.ListIndex + 1).Index).MinHit & "/" & ObjData(ArmasHerrero(lstArmas.ListIndex).Index).MaxHit
+            desc.Caption = "Golpe: " & ObjData(ArmasHerrero(lstArmas.ListIndex + 1).Index).MinHit & "/" & ObjData(ArmasHerrero(lstArmas.ListIndex + 1).Index).MaxHit
         Case 2
             Call Grh_Render_To_Hdc(picture1, ObjData(ArmadurasHerrero(lstArmas.ListIndex).Index).GrhIndex, 0, 0)
             tmpTexts = AddMaterialNames((ArmadurasHerrero(lstArmas.ListIndex).Index))


### PR DESCRIPTION
Se corrigió un índice utilizado al mostrar el "Golpe" de un arma en el panel de herrería (frmHerrero.frm, evento lstArmas_Click, Case 1), de modo que MinHit y MaxHit se obtienen del mismo ítem (ambos usan lstArmas.ListIndex + 1).

Anteriormente, MinHit usaba lstArmas.ListIndex + 1 pero MaxHit usaba lstArmas.ListIndex sin el +1, haciendo que el daño máximo mostrado correspondiera al arma anterior de la lista en vez del arma seleccionada. Esto afectaba a todas las armas del listado