### PR TITLE
Send pickup destination byte (0) in `WritePickUp` to match fixed ePickUp format

### DIFF
--- a/CODIGO/Protocol_Writes.bas
+++ b/CODIGO/Protocol_Writes.bas
@@ -464,6 +464,7 @@ Public Sub WritePickUp()
     Call Writer.WriteInt16(ClientPacketID.ePickUp)
     Call Writer.WriteInt8(UserPos.x)
     Call Writer.WriteInt8(UserPos.y)
+    Call Writer.WriteInt8(0)
     Call modNetwork.send(Writer)
     '<EhFooter>
     Exit Sub


### PR DESCRIPTION
### Motivation

- Align the VB6 client packet writers with the coordinated fixed `ePickUp`/`eDrop` protocol while preserving the legacy VB6 UX and existing writer signatures.

### Description

- Updated `WritePickUp()` to emit the fixed five-byte `ePickUp` layout by writing `ClientPacketID.ePickUp`, `UserPos.x`, `UserPos.y`, and then a `0` destination-slot byte before calling `modNetwork.send(Writer)`; the function signature remains `Public Sub WritePickUp()`.
- Verified `WriteDrop(ByVal Slot As Byte, ByVal Amount As Long)` preserves the required ordering of `ClientPacketID.eDrop`, `Slot`, `Amount`, the existing `TS_Drop` increment and counter write, and then `UserPos.x`/`UserPos.y` prior to sending, with no signature change.
- Did not add packet IDs, optional fields, capability messages, nearby-targeting UI, or change any callers; only `CODIGO/Protocol_Writes.bas` was modified.

### Testing

- Ran a focused Python validation that parsed `CODIGO/PacketId.bas` and `CODIGO/Protocol_Writes.bas` and asserted `ePickUp = 81`, `eDrop = 93`, writer-call ordering, and produced golden packets `51 00 2D 48 00` (5 bytes) and `5D 00 07 01 00 00 00 04 03 02 01 2D 48` (13 bytes), which passed.
- Performed a repository audit with `rg` to confirm all `WritePickUp`/`WriteDrop` call sites remain unchanged and found no manual `ePickUp`/`eDrop` writers outside the centralized writers.
- Ran `git diff --check` and `git status` validations which reported a clean working state after the change.
- Could not run VB6 unit tests, project compilation, or runtime/manual regression checks because a VB6 build/runtime toolchain was not available in this environment, so those checks remain to be executed in a Windows/VB6-capable environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7624a78ae08328998907bd53a28b4b)