### PR TITLE
Load shipped Cardo font file

### DIFF
--- a/CODIGO/Recursos.bas
+++ b/CODIGO/Recursos.bas
@@ -2383,7 +2383,7 @@ CargarAnimEscudos_Err:
 End Sub
 
 Sub LoadFonts()
-    If LoadFont("Cardo.ttf") Then
+    If LoadFont("Cardo-Regular.ttf") Then
         frmMain.NombrePJ.font.Name = "Cardo"
     End If
     If LoadFont("Alegreya Sans AO.ttf") Then
@@ -2436,9 +2436,11 @@ End Sub
 
 Function LoadFont(Name As String) As Boolean
     Static YaMostreError As Boolean
-    LoadFont = AddFontResourceEx(App.path & "\..\Recursos\OUTPUT\" & Name, FR_PRIVATE, 0&) <> 0
+    Dim FontPath As String
+    FontPath = App.path & "\..\Recursos\OUTPUT\" & Name
+    LoadFont = AddFontResourceEx(FontPath, FR_PRIVATE, 0&) <> 0
     If Not YaMostreError And Not LoadFont Then
-        Call MsgBox(JsonLanguage.Item("MENSAJEBOX_ERROR_FUENTES"), vbOKOnly, JsonLanguage.Item("MENSAJEBOX_ERROR_CARGA"))
+        Call MsgBox(JsonLanguage.Item("MENSAJEBOX_ERROR_FUENTES") & vbCrLf & vbCrLf & "Font: " & Name & vbCrLf & "Path: " & FontPath, vbOKOnly, JsonLanguage.Item("MENSAJEBOX_ERROR_CARGA"))
         YaMostreError = True
     End If
 End Function


### PR DESCRIPTION
## Summary
- load Cardo-Regular.ttf, which is the Cardo file present in Recursos/OUTPUT
- keep assigning the loaded family as Cardo for the player name font
- include the failed font name and resolved path in the startup font error dialog

## Validation
- Verified Recursos/OUTPUT contains Cardo-Regular.ttf.
- Not run: VB6 compile was not run for this small resource-path fix.