### PR TITLE
Force Forgat as new character home city

### DIFF
--- a/CODIGO/Declares.bas
+++ b/CODIGO/Declares.bas
@@ -989,6 +989,7 @@ Public Const NUMATRIBUTOS                       As Byte = 5
 Public Const NUMCLASES                          As Byte = 12
 Public Const NUMRAZAS                           As Byte = 6
 Public Const NUMCIUDADES                        As Byte = 6
+Public Const CHARACTER_CREATION_HOME_FORGAT       As Byte = 7 ' Must match server e_City.cForgat.
 Type tModRaza
     Fuerza As Integer
     Agilidad As Integer

--- a/CODIGO/ModLogin.bas
+++ b/CODIGO/ModLogin.bas
@@ -494,7 +494,7 @@ Public Sub CreateCharacter(ByVal Name As String, ByVal Race As Integer, ByVal Ge
     UserStats.Sexo = Gender
     UserStats.Clase = Class
     MiCabeza = Head
-    UserStats.Hogar = HomeCity
+    UserStats.Hogar = CHARACTER_CREATION_HOME_FORGAT
     #If PYMMO = 1 Then
         Call modNetwork.Connect(IPdelServidor, PuertoDelServidor)
         Call LoginOrConnect(E_MODO.CrearNuevoPj)

--- a/CODIGO/ModUtils.bas
+++ b/CODIGO/ModUtils.bas
@@ -626,10 +626,10 @@ Sub IniciarCrearPj()
     Next i
     frmCrearPersonaje.lstRaza.ListIndex = 0
     frmCrearPersonaje.lstHogar.Clear
-    For i = LBound(ListaCiudades()) To UBound(ListaCiudades())
-        frmCrearPersonaje.lstHogar.AddItem ListaCiudades(i)
-    Next i
+    frmCrearPersonaje.lstHogar.AddItem ListaCiudades(eCiudad.cForgat)
     frmCrearPersonaje.lstHogar.ListIndex = 0
+    frmCrearPersonaje.lstHogar.enabled = False
+    UserStats.Hogar = CHARACTER_CREATION_HOME_FORGAT
     frmCrearPersonaje.lstProfesion.Clear
     For i = LBound(ListaClases()) To UBound(ListaClases())
         frmCrearPersonaje.lstProfesion.AddItem ListaClases(i)

--- a/CODIGO/Protocol_Writes.bas
+++ b/CODIGO/Protocol_Writes.bas
@@ -221,7 +221,7 @@ Public Sub WriteLoginNewChar(ByVal Name As String, ByVal Race As Integer, ByVal 
     Call Writer.WriteInt8(Gender)
     Call Writer.WriteInt8(Class)
     Call Writer.WriteInt16(Head)
-    Call Writer.WriteInt8(HomeCity)
+    Call Writer.WriteInt8(CHARACTER_CREATION_HOME_FORGAT)
     Call modNetwork.send(Writer)
     '<EhFooter>
     Exit Sub
@@ -304,7 +304,7 @@ Public Sub WriteLoginNewChar(ByVal Name As String, ByVal Race As Integer, ByVal 
 116     Call Writer.WriteInt(Gender)
 118     Call Writer.WriteInt(Class)
 120     Call Writer.WriteInt(Head)
-122     Call Writer.WriteInt(HomeCity)
+122     Call Writer.WriteInt(CHARACTER_CREATION_HOME_FORGAT)
     
 130     Call modNetwork.send(Writer)
         '<EhFooter>

--- a/CODIGO/frmConnect.frm
+++ b/CODIGO/frmConnect.frm
@@ -463,14 +463,6 @@ End Sub
                         frmCrearPersonaje.lstGenero.ListIndex = frmCrearPersonaje.lstGenero.ListIndex - 1
                     End If
                 End If
-                ' Hogar inicial
-                ' Shugar: Arreglo los botones para seleccionar el hogar inicial.
-                If x > 416 And x < 433 And y > 323 And y < 338 Then
-                    Call Rotacion_boton_adelante_ciudades
-                End If
-                If x > 297 And x < 314 And y > 321 And y < 340 Then
-                    Call Rotacion_boton_atras_ciudades
-                End If
                 If x >= 289 And x < 289 + 160 And y >= 525 And y < 525 + 37 Then 'Boton > Volver
                     Call ao20audio.PlayWav(SND_CLICK)
                     AlphaNiebla = 25
@@ -494,7 +486,7 @@ End Sub
                     UserStats.Raza = frmCrearPersonaje.lstRaza.ListIndex + 1
                     UserStats.Sexo = frmCrearPersonaje.lstGenero.ListIndex + 1
                     UserStats.Clase = frmCrearPersonaje.lstProfesion.ListIndex + 1
-                    UserStats.Hogar = frmCrearPersonaje.lstHogar.ListIndex + 1
+                    UserStats.Hogar = CHARACTER_CREATION_HOME_FORGAT
                     If frmCrearPersonaje.CheckData() Then
                         UserPassword = CuentaPassword
                         StopCreandoCuenta = True
@@ -765,23 +757,6 @@ Private Sub render_MouseUp(Button As Integer, Shift As Integer, x As Single, y A
 
             End If
             
-            ' Hogar inicial
-            ' Shugar: Arreglo los botones para seleccionar el hogar inicial.
-            
-            If x > 416 And x < 433 And y > 323 And y < 338 Then
-            
-                Call Rotacion_boton_adelante_ciudades
-
-            End If
-            
-            
-            If x > 297 And x < 314 And y > 321 And y < 340 Then
-                
-                Call Rotacion_boton_atras_ciudades
-                
-            End If
-
-            
             If x >= 289 And x < 289 + 160 And y >= 525 And y < 525 + 37 Then 'Boton > Volver
                 Call ao20audio.PlayWav(SND_CLICK)
                 'UserMap = 323
@@ -817,7 +792,7 @@ Private Sub render_MouseUp(Button As Integer, Shift As Integer, x As Single, y A
                 UserStats.Raza = frmCrearPersonaje.lstRaza.ListIndex + 1
                 UserStats.Sexo = frmCrearPersonaje.lstGenero.ListIndex + 1
                 UserStats.Clase = frmCrearPersonaje.lstProfesion.ListIndex + 1
-                UserStats.Hogar = frmCrearPersonaje.lstHogar.ListIndex + 1
+                UserStats.Hogar = CHARACTER_CREATION_HOME_FORGAT
                
                 If frmCrearPersonaje.CheckData() Then
                     UserPassword = CuentaPassword
@@ -1077,28 +1052,6 @@ Private Sub Rotacion_boton_atras_clase()
             frmCrearPersonaje.lstProfesion.ListIndex = eClass.Hunter - 1
         Case eClass.Trabajador - 1
             frmCrearPersonaje.lstProfesion.ListIndex = eClass.Warrior - 1
-    End Select
-End Sub
-
-Private Sub Rotacion_boton_adelante_ciudades()
-    Select Case frmCrearPersonaje.lstHogar.ListIndex
-        Case eCiudad.cUllathorpe - 1
-            frmCrearPersonaje.lstHogar.ListIndex = eCiudad.cNix - 1
-        Case eCiudad.cNix - 1
-            frmCrearPersonaje.lstHogar.ListIndex = eCiudad.cArghal - 1
-        Case eCiudad.cArghal - 1
-            frmCrearPersonaje.lstHogar.ListIndex = eCiudad.cUllathorpe - 1
-    End Select
-End Sub
-
-Private Sub Rotacion_boton_atras_ciudades()
-    Select Case frmCrearPersonaje.lstHogar.ListIndex
-        Case eCiudad.cUllathorpe - 1
-            frmCrearPersonaje.lstHogar.ListIndex = eCiudad.cArghal - 1
-        Case eCiudad.cArghal - 1
-            frmCrearPersonaje.lstHogar.ListIndex = eCiudad.cNix - 1
-        Case eCiudad.cNix - 1
-            frmCrearPersonaje.lstHogar.ListIndex = eCiudad.cUllathorpe - 1
     End Select
 End Sub
 

--- a/CODIGO/frmCrearPersonaje.frm
+++ b/CODIGO/frmCrearPersonaje.frm
@@ -16,6 +16,7 @@ Begin VB.Form frmCrearPersonaje
    StartUpPosition =   2  'CenterScreen
    Begin VB.ComboBox lstHogar 
       BackColor       =   &H00000000&
+      Enabled         =   0   'False
       BeginProperty Font 
          Name            =   "MS Sans Serif"
          Size            =   8.25
@@ -30,7 +31,9 @@ Begin VB.Form frmCrearPersonaje
       Left            =   13680
       Style           =   2  'Dropdown List
       TabIndex        =   29
+      TabStop         =   0   'False
       Top             =   5640
+      Visible         =   0   'False
       Width           =   1785
    End
    Begin VB.ComboBox cabeza 
@@ -861,7 +864,7 @@ Private Sub render_MouseUp(Button As Integer, Shift As Integer, x As Single, y A
         UserStats.Raza = lstRaza.ListIndex + 1
         UserStats.Sexo = lstGenero.ListIndex + 1
         UserStats.Clase = lstProfesion.ListIndex + 1
-        UserStats.Hogar = lstHogar.ListIndex + 1
+        UserStats.Hogar = CHARACTER_CREATION_HOME_FORGAT
         UserAtributos(1) = val(lbFuerza.Caption) + val(modfuerza.Caption)
         UserAtributos(2) = val(lbAgilidad.Caption) + val(modAgilidad.Caption)
         UserAtributos(3) = val(lbInteligencia.Caption) + val(modInteligencia.Caption)


### PR DESCRIPTION
Character creation now always sets the home city to Forgat by introducing a shared constant and using it across creation, login packet writes, and form state initialization. The home-city selector was effectively removed from the flow (disabled/hidden and no rotation handlers) to keep client behavior aligned with the server-side city assignment.