### PR TITLE
Add text channel enum and optional chat param

### DIFF
--- a/CODIGO/General.bas
+++ b/CODIGO/General.bas
@@ -263,8 +263,10 @@ Sub AddtoRichTextBox(ByRef RichTextBox As RichTextBox, _
                      Optional ByVal blue As Integer, _
                      Optional ByVal bold As Boolean = False, _
                      Optional ByVal italic As Boolean = False, _
-                     Optional ByVal bCrLf As Boolean = False)
+                     Optional ByVal bCrLf As Boolean = False, _
+                     Optional ByVal Channel As e_TextChannel = TEXTCHANNEL_SYSTEM)
     On Error GoTo AddtoRichTextBox_Err
+    ' Channel is intentionally ignored until a versioned packet carries it.
     Dim bUrl     As Boolean
     Dim sMax     As Long
     Dim sPos     As Long

--- a/CODIGO/General.bas
+++ b/CODIGO/General.bas
@@ -266,7 +266,7 @@ Sub AddtoRichTextBox(ByRef RichTextBox As RichTextBox, _
                      Optional ByVal bCrLf As Boolean = False, _
                      Optional ByVal Channel As e_TextChannel = TEXTCHANNEL_SYSTEM)
     On Error GoTo AddtoRichTextBox_Err
-    ' Channel is intentionally ignored until a versioned packet carries it.
+    ' Channel defaults to SYSTEM for legacy packets that do not carry the field.
     Dim bUrl     As Boolean
     Dim sMax     As Long
     Dim sPos     As Long

--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -1870,6 +1870,7 @@ End Sub
 Private Sub HandleConsoleMessage()
     On Error GoTo errhandler
     Dim chat           As String
+    Dim Channel        As e_TextChannel
     Dim FontIndex      As Integer
     Dim str            As String
     Dim R              As Byte
@@ -1886,6 +1887,7 @@ Private Sub HandleConsoleMessage()
     Dim Valor          As String
     Dim staminaCost    As String
     chat = Reader.ReadString8()
+    Channel = Reader.ReadInt8()
     FontIndex = Reader.ReadInt8()
     If ChatGlobal = 0 And FontIndex = FontTypeNames.FONTTYPE_GLOBAL Then Exit Sub
     QueEs = ReadField(1, chat, Asc("*"))
@@ -1955,10 +1957,10 @@ Private Sub HandleConsoleMessage()
         Else
             B = val(str)
         End If
-        Call AddtoRichTextBox(frmMain.RecTxt, Left$(chat, InStr(1, chat, "~") - 1), R, G, B, val(ReadField(5, chat, 126)) <> 0, val(ReadField(6, chat, 126)) <> 0)
+        Call AddtoRichTextBox(frmMain.RecTxt, Left$(chat, InStr(1, chat, "~") - 1), R, G, B, val(ReadField(5, chat, 126)) <> 0, val(ReadField(6, chat, 126)) <> 0, False, Channel)
     Else
         With FontTypes(FontIndex)
-            Call AddtoRichTextBox(frmMain.RecTxt, chat, .red, .green, .blue, .bold, .italic)
+            Call AddtoRichTextBox(frmMain.RecTxt, chat, .red, .green, .blue, .bold, .italic, False, Channel)
             If EsGM Then
                 Call frmPanelgm.CadenaChat(chat)
             End If
@@ -1991,6 +1993,7 @@ End Sub
 Private Sub HandleLocaleMsg()
     On Error GoTo errhandler
     Dim chat      As String
+    Dim Channel   As e_TextChannel
     Dim FontIndex As Integer
     Dim str       As String
     Dim R         As Byte
@@ -1999,6 +2002,7 @@ Private Sub HandleLocaleMsg()
     Dim id        As Integer
     id = Reader.ReadInt16()
     chat = Reader.ReadString8()
+    Channel = Reader.ReadInt8()
     FontIndex = Reader.ReadInt8()
     chat = Locale_Parse_ServerMessage(id, chat)
     If InStr(1, chat, "~") Then
@@ -2020,10 +2024,10 @@ Private Sub HandleLocaleMsg()
         Else
             B = val(str)
         End If
-        Call AddtoRichTextBox(frmMain.RecTxt, Left$(chat, InStr(1, chat, "~") - 1), R, G, B, val(ReadField(5, chat, 126)) <> 0, val(ReadField(6, chat, 126)) <> 0)
+        Call AddtoRichTextBox(frmMain.RecTxt, Left$(chat, InStr(1, chat, "~") - 1), R, G, B, val(ReadField(5, chat, 126)) <> 0, val(ReadField(6, chat, 126)) <> 0, False, Channel)
     Else
         With FontTypes(FontIndex)
-            Call AddtoRichTextBox(frmMain.RecTxt, chat, .red, .green, .blue, .bold, .italic)
+            Call AddtoRichTextBox(frmMain.RecTxt, chat, .red, .green, .blue, .bold, .italic, False, Channel)
         End With
     End If
     Exit Sub

--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -1887,8 +1887,8 @@ Private Sub HandleConsoleMessage()
     Dim Valor          As String
     Dim staminaCost    As String
     chat = Reader.ReadString8()
-    Channel = Reader.ReadInt8()
     FontIndex = Reader.ReadInt8()
+    If Reader.GetAvailable() > 0 Then Channel = Reader.ReadInt8()
     If ChatGlobal = 0 And FontIndex = FontTypeNames.FONTTYPE_GLOBAL Then Exit Sub
     QueEs = ReadField(1, chat, Asc("*"))
     Select Case QueEs
@@ -2002,8 +2002,8 @@ Private Sub HandleLocaleMsg()
     Dim id        As Integer
     id = Reader.ReadInt16()
     chat = Reader.ReadString8()
-    Channel = Reader.ReadInt8()
     FontIndex = Reader.ReadInt8()
+    If Reader.GetAvailable() > 0 Then Channel = Reader.ReadInt8()
     chat = Locale_Parse_ServerMessage(id, chat)
     If InStr(1, chat, "~") Then
         str = ReadField(2, chat, 126)

--- a/CODIGO/Recursos.bas
+++ b/CODIGO/Recursos.bas
@@ -78,6 +78,24 @@ Public Enum FontTypeNames
     [FONTTYPE_MAX]
 End Enum
 
+' Semantic destination reserved for the future channel-aware text interface.
+Public Enum e_TextChannel
+    TEXTCHANNEL_SYSTEM = 0
+    TEXTCHANNEL_COMBAT
+    TEXTCHANNEL_QUEST
+    TEXTCHANNEL_PROGRESSION
+    TEXTCHANNEL_ECONOMY
+    TEXTCHANNEL_EVENT
+    TEXTCHANNEL_GROUP
+    TEXTCHANNEL_GUILD
+    TEXTCHANNEL_FACTION
+    TEXTCHANNEL_NEARBY
+    TEXTCHANNEL_WHISPER
+    TEXTCHANNEL_GLOBAL
+    TEXTCHANNEL_SERVER_STAFF
+    TEXTCHANNEL_MAX
+End Enum
+
 Public FontTypes([FONTTYPE_MAX] - 1) As tFont
 ' *********************************************************
 ' FIN - FUENTES


### PR DESCRIPTION
Introduces a new `e_TextChannel` enum in `Recursos.bas` to define semantic text destinations for future channel-aware messaging. Updates `AddtoRichTextBox` in `General.bas` with an optional `Channel` argument (defaulting to `TEXTCHANNEL_SYSTEM`) and documents that it is intentionally ignored until protocol support is added.