### PR TITLE
Sync RemortState protocol ID

### DIFF
--- a/CODIGO/PacketId.bas
+++ b/CODIGO/PacketId.bas
@@ -208,6 +208,7 @@ Public Enum ServerPacketID
     eChangeSkinSlot
     eGuildConfig
     eShowPickUpObj
+    eRemortState
     eMaxPacket
     [PacketCount]
 End Enum


### PR DESCRIPTION
## Summary
- append `eRemortState` to the legacy VB6 client's generated server packet enum
- preserve all existing packet ordinals

## Scope
Protocol parity only. The legacy client has no Remort handler, capability implementation, UI, command, request, or gameplay behavior. The server never sends this packet unless `HOO_CAP_REMORT_V1` was negotiated.

## Validation
- native VB6 client build passed
- cross-project ordinal audit confirms `RemortState = 202`
- `git diff --check` passed

The pre-existing local `Argentum20.vbp` changes are not part of this PR.