### PR TITLE
Sync Remort operation packet IDs

### DIFF
--- a/CODIGO/PacketId.bas
+++ b/CODIGO/PacketId.bas
@@ -209,6 +209,7 @@ Public Enum ServerPacketID
     eGuildConfig
     eShowPickUpObj
     eRemortState
+    eRemortResult
     eMaxPacket
     [PacketCount]
 End Enum
@@ -531,6 +532,7 @@ Public Enum ClientPacketID
     eAntiMacroMessage
     eModifyCastleWhiteList
     eHooClientCapabilities
+    eRequestRemort
     eMaxPacket
     [PacketCount]
 End Enum


### PR DESCRIPTION
## Summary
- Append RequestRemort and RemortResult protocol IDs.
- Preserve all existing packet ordinals.
- Maintain protocol parity with ProtocolGenerator, the AO20 server, and HOO.

## Scope
Protocol definitions only. This does not add:
- Remort capability negotiation.
- A RequestRemort sender.
- RemortResult handling.
- Remort UI or gameplay behavior.

The stock legacy client remains unable to invoke Remort.

## Validation
- VB6 client build passed.
- git diff --check passed.