### PR TITLE
Sync HOO targeted spell cast packet IDs

### DIFF
--- a/CODIGO/PacketId.bas
+++ b/CODIGO/PacketId.bas
@@ -210,6 +210,7 @@ Public Enum ServerPacketID
     eShowPickUpObj
     eRemortState
     eRemortResult
+    eHooTargetedSpellCastResult
     eMaxPacket
     [PacketCount]
 End Enum
@@ -533,6 +534,7 @@ Public Enum ClientPacketID
     eModifyCastleWhiteList
     eHooClientCapabilities
     eRequestRemort
+    eHooTargetedSpellCast
     eMaxPacket
     [PacketCount]
 End Enum


### PR DESCRIPTION
## Summary
- append `eHooTargetedSpellCast` to `ClientPacketID`
- append `eHooTargetedSpellCastResult` to `ServerPacketID`

## Compatibility
- protocol enum synchronization only
- no sender, handler, capability, UI, or gameplay behavior added
- all existing packet ordinals remain unchanged
- the stock VB6 client continues using its existing spell-casting flow

## Validation
- packet additions match ProtocolGenerator and the VB6 server
- `git diff --check` passes