### PR TITLE
Sync modern house door packet IDs

### DIFF
--- a/CODIGO/PacketId.bas
+++ b/CODIGO/PacketId.bas
@@ -211,6 +211,7 @@ Public Enum ServerPacketID
     eRemortState
     eRemortResult
     eHooTargetedSpellCastResult
+    eHooHouseDoorActionResult
     eMaxPacket
     [PacketCount]
 End Enum
@@ -535,6 +536,7 @@ Public Enum ClientPacketID
     eHooClientCapabilities
     eRequestRemort
     eHooTargetedSpellCast
+    eHooHouseDoorAction
     eMaxPacket
     [PacketCount]
 End Enum


### PR DESCRIPTION
## Summary
- appends `eHooHouseDoorActionResult` to the server packet enum
- appends `eHooHouseDoorAction` to the client packet enum
- keeps the legacy client behavior unchanged

## Compatibility
- no sender or handler was added
- no UI or gameplay behavior changed
- `eUseKey` remains packet 209 with its existing wire layout
- no existing packet ordinal changed

## Validation
- Windows VB6 production build passed
- git diff --check passed